### PR TITLE
feat(src): support variable substitution and concatenation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ _build/
 _checkouts/
 src/hocon_parser.erl
 src/hocon_scanner.erl
+
+# IDEs
+/.idea/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ See: https://lightbend.github.io/config/
 - No unicode support (at least not verified).
 - The forbidden character `@` is allowed in unquoted strings.
 - Unquoted strings are parsed as atoms while quoted are parsed as binaries.
+- No whitespaces in `key`. Expressions like `a b c : 42` are not allowed.
 
 ## Test Data
 

--- a/rebar.config
+++ b/rebar.config
@@ -31,3 +31,4 @@
 {escript_wrappers_windows, ["cmd", "powershell"]}.
 {escript_comment, "%% Hocon 0.1.0"}.
 {escript_emu_args, "%%! +sbtu +A1\n"}.
+{yrl_opts, [verbose, warnings_as_errors]}.

--- a/sample-configs/variable-subst.conf
+++ b/sample-configs/variable-subst.conf
@@ -13,7 +13,24 @@ e=${num}
 g=${x}"quoted+string"
 h=${istrue}
 
+j {
+a=${x}${y}${z}
+b=${x}
+}
+
+m = {
+a=${x}${y}${z}
+b=${x}
+}
+
+nested=${m}
+
 #{ok,#{a => <<"foo">>,b => <<"foobar">>,c => <<"fooisfoo">>,
 #      d => <<"barisbar">>,e => 42,g => <<"fooquoted+string">>,
-#      h => true,istrue => true,num => 42,w => <<"foobarbaz">>,
-#      x => <<"foo">>,y => <<"bar">>,z => <<"baz">>}}
+#      h => true,istrue => true,
+#      j => #{a => <<"foobarbaz">>,b => <<"foo">>},
+#      m => #{a => <<"foobarbaz">>,b => <<"foo">>},
+#      nested => #{a => <<"foobarbaz">>,b => <<"foo">>},
+#      num => 42,w => <<"foobarbaz">>,x => <<"foo">>,
+#      y => <<"bar">>,z => <<"baz">>}}
+

--- a/sample-configs/variable-subst.conf
+++ b/sample-configs/variable-subst.conf
@@ -1,0 +1,19 @@
+# variable substitution and concatenation
+x="foo"
+y=bar
+z="baz"
+w="foo"bar"baz"
+num=42
+istrue=true
+
+a=${x}
+b=${x}${y}
+c=${x}is${x}, d=${y}isbar
+e=${num}
+g=${x}"quoted+string"
+h=${istrue}
+
+#{ok,#{a => <<"foo">>,b => <<"foobar">>,c => <<"fooisfoo">>,
+#      d => <<"barisbar">>,e => 42,g => <<"fooquoted+string">>,
+#      h => true,istrue => true,num => 42,w => <<"foobarbaz">>,
+#      x => <<"foo">>,y => <<"bar">>,z => <<"baz">>}}

--- a/src/hocon.erl
+++ b/src/hocon.erl
@@ -87,7 +87,7 @@ parse(Tokens) ->
 
 -spec(transform(config(), ctx()) -> {ok, config()}).
 transform(Config, Ctx) ->
-    try include(concat(substitute(Config)), Ctx) of
+    try include(substitute(Config), Ctx) of
         RootMap -> {ok, RootMap}
     catch
         error:Reason:St -> {error, {Reason,St}}
@@ -128,29 +128,17 @@ substitute(RootMap) ->
 
 substitute(MapVal, RootMap) when is_map(MapVal) ->
     maps:map(fun(_Key, Substrings) -> substitute(Substrings, RootMap) end, MapVal);
-substitute(Substrings = [{substr, _S}|_More], RootMap) ->
-    lists:map(fun({substr, S}) -> {substituted, substitute(S, RootMap)} end, Substrings);
-substitute(<<"${", Var/binary>>, RootMap) ->
-    Varname = binary:replace(Var, <<"}">>, <<"">>),
+substitute({concat, Substrings}, RootMap) ->
+    iolist_to_binary(lists:map(fun(S) -> substitute(S, RootMap) end, Substrings));
+substitute({var, Name}, RootMap) ->
+    do_substitute(Name, RootMap);
+substitute(Value, _RootMap) -> Value.
+
+do_substitute(Varname, RootMap) ->
     case nested_get(paths(Varname), RootMap) of
         undefined -> error({variable_not_found, Varname});
         Val -> substitute(Val, RootMap)
-    end;
-substitute(Value, _RootMap) -> Value.
-
-concat(RootMap) when is_map(RootMap) ->
-    maps:map(fun(_Key, Val) -> concat(Val) end, RootMap);
-concat(Substrings = [{substituted, _V}|_More]) ->
-    do_concat(lists:map(fun(V) -> concat(V) end, Substrings));
-concat(L) when is_list(L) ->
-    lists:map(fun(Val) -> concat(Val) end, L);
-concat({substituted, S}) -> concat(S);
-concat(Val) -> Val.
-
-do_concat(L=[V|_More]) when is_binary(V) ->
-    iolist_to_binary(L);
-do_concat([V]) -> V.
-
+    end.
 
 expand({Members}) ->
     expand(Members);

--- a/src/hocon_parser.yrl
+++ b/src/hocon_parser.yrl
@@ -7,17 +7,17 @@ Nonterminals
   Elements
   Element
   Directive
-  Key
-  Value.
+  Value
+  Substrings.
 
 Terminals
-  '{' '}' '[' ']' ',' ':' '='
-  bool atom integer float string
+  '{' '}' '[' ']' ','
+  bool integer float string
   percent bytesize duration variable
-  include.
+  include key.
 
 Rootsymbol HOCON.
-
+Right 100 string variable.
 HOCON -> Object: '$1'.
 HOCON -> Members : '$1'.
 
@@ -28,9 +28,7 @@ Members -> Member ',' Members : ['$1'|'$3'].
 Members -> Member Members : ['$1'|'$2'].
 Members -> Member : ['$1'].
 
-Member -> Key Object : {'$1', '$2'}.
-Member -> Key ':' Element : {'$1', '$3'}.
-Member -> Key '=' Element : {'$1', '$3'}.
+Member -> key Element : {iolist_to_binary(value_of('$1')), '$2'}.
 Member -> Directive : '$1'.
 
 Array -> '[' Elements ']' : '$2'.
@@ -41,21 +39,22 @@ Elements -> Element Elements : ['$1'|'$2'].
 Elements -> Element : ['$1'].
 
 Element -> Value : '$1'.
+Element -> Substrings : '$1'.
 
 Directive -> include string : {'$include', value_of('$2')}.
 
-Key -> atom : value_of('$1').
-Key -> string : iolist_to_binary(value_of('$1')).
+%% create {substr, Value} tuple to distinguish from an array of strings
+Substrings -> string Substrings : [{substr, iolist_to_binary(value_of('$1'))} | '$2'].
+Substrings -> variable Substrings : [{substr, iolist_to_binary(value_of('$1'))} | '$2'].
+Substrings -> string : [{substr, iolist_to_binary(value_of('$1'))}].
+Substrings -> variable : [{substr, iolist_to_binary(value_of('$1'))}].
 
 Value -> bool : value_of('$1').
-Value -> atom : value_of('$1').
 Value -> integer : value_of('$1').
 Value -> float : value_of('$1').
-Value -> string : iolist_to_binary(value_of('$1')).
 Value -> percent : value_of('$1').
 Value -> bytesize : value_of('$1').
 Value -> duration : value_of('$1').
-Value -> variable : value_of('$1').
 Value -> Array : '$1'.
 Value -> Object : '$1'.
 

--- a/src/hocon_parser.yrl
+++ b/src/hocon_parser.yrl
@@ -8,6 +8,7 @@ Nonterminals
   Element
   Directive
   Value
+  Substring
   Substrings.
 
 Terminals
@@ -39,15 +40,15 @@ Elements -> Element Elements : ['$1'|'$2'].
 Elements -> Element : ['$1'].
 
 Element -> Value : '$1'.
-Element -> Substrings : '$1'.
+Element -> Substrings : maybe_concat('$1').
 
 Directive -> include string : {'$include', value_of('$2')}.
 
-%% create {substr, Value} tuple to distinguish from an array of strings
-Substrings -> string Substrings : [{substr, iolist_to_binary(value_of('$1'))} | '$2'].
-Substrings -> variable Substrings : [{substr, iolist_to_binary(value_of('$1'))} | '$2'].
-Substrings -> string : [{substr, iolist_to_binary(value_of('$1'))}].
-Substrings -> variable : [{substr, iolist_to_binary(value_of('$1'))}].
+Substrings -> Substring Substrings : ['$1' | '$2'].
+Substrings -> Substring : ['$1'].
+
+Substring -> string : iolist_to_binary(value_of('$1')).
+Substring -> variable : value_of('$1').
 
 Value -> bool : value_of('$1').
 Value -> integer : value_of('$1').
@@ -61,4 +62,7 @@ Value -> Object : '$1'.
 Erlang code.
 
 value_of(Token) -> element(3, Token).
+
+maybe_concat([S]) -> S;
+maybe_concat(S) -> {concat, S}.
 

--- a/src/hocon_scanner.xrl
+++ b/src/hocon_scanner.xrl
@@ -41,8 +41,8 @@ Ignored             = {WhiteSpace}|{NewLine}|{Comment}
 %% Punctuator
 Punctuator          = [{}\[\],]
 
-%% KeyValue Operator
-KV                  = [:=]
+%% KeyValue
+KvSeparator         = [:=]
 
 %% Bool
 Bool                = true|false|on|off
@@ -53,10 +53,6 @@ Unquoted            = {Letter}[A-Za-z0-9_\.@%\-\|]*
 
 %% Bool
 Bool                = true|false|on|off
-
-%% Name(Atom in Erlang)
-Letter              = [A-Za-z]
-Name                = {Letter}[A-Za-z0-9_\.@-]*
 
 %% Integer
 Digit               = [0-9]
@@ -87,7 +83,8 @@ Duration            = {Digit}+(d|D|h|H|m|M|s|S|ms|MS)
 Literal             = {Bool}|{Integer}|{Float}|{String}|{Unquoted}|{Percent}{Bytesize}|{Duration}
 Variable            = \$\{{Unquoted}\}
 
-Key                 = ({Unquoted}|{String})({WhiteSpace}*){KV}
+%% Key
+Key                 = ({Unquoted}|{String})({WhiteSpace}*){KvSeparator}
 ObjectKey           = ({Unquoted}|{String})({WhiteSpace}*){
 
 Rules.

--- a/src/hocon_scanner.xrl
+++ b/src/hocon_scanner.xrl
@@ -95,7 +95,7 @@ Rules.
 {Ignored}         : skip_token.
 {Punctuator}      : {token, {list_to_atom(string:trim(TokenChars)), TokenLine}}.
 {Bool}            : {token, {bool, TokenLine, bool(TokenChars)}}.
-{Unquoted}        : {token, {string, TokenLine, iolist_to_binary(TokenChars)}}.
+{Unquoted}        : {token, maybe_include(TokenChars, TokenLine)}.
 {Integer}         : {token, {integer, TokenLine, list_to_integer(TokenChars)}}.
 {Float}           : {token, {float, TokenLine, list_to_float(TokenChars)}}.
 {String}          : {token, {string, TokenLine, iolist_to_binary(unquote(TokenChars))}}.
@@ -103,7 +103,7 @@ Rules.
 {Bytesize}        : {token, {bytesize, TokenLine, bytesize(TokenChars)}}.
 {Percent}         : {token, {percent, TokenLine, percent(TokenChars)}}.
 {Duration}        : {token, {duration, TokenLine, duration(TokenChars)}}.
-{Variable}        : {token, {variable, TokenLine, TokenChars}}.
+{Variable}        : {token, {variable, TokenLine, {var, var_ref_name(TokenChars)}}}.
 {Key}             : {token, {key, TokenLine, iolist_to_binary(string:trim(TokenChars, both, "=:\" "))}}.
 {ObjectKey}       : {token, {key, TokenLine, iolist_to_binary(string:trim(TokenChars, both, "\"{ "))}, "{" }.
 
@@ -119,8 +119,8 @@ Erlang code.
 -define(MEGABYTE, (?KILOBYTE*1024)). %1048576
 -define(GIGABYTE, (?MEGABYTE*1024)). %1073741824
 
-identifier("include", TokenLine)  -> {include, TokenLine};
-identifier(TokenChars, TokenLine) -> {atom, TokenLine, list_to_atom(TokenChars)}.
+maybe_include("include", TokenLine)  -> {include, TokenLine};
+maybe_include(TokenChars, TokenLine) -> {string, TokenLine, iolist_to_binary(TokenChars)}.
 
 bool("true")  -> true;
 bool("false") -> false;
@@ -155,3 +155,6 @@ duration(Val, "m")  -> Val * ?MINUTE;
 duration(Val, "s")  -> Val * ?SECOND;
 duration(Val, "ms") -> Val.
 
+var_ref_name("${" ++ Name_CR) ->
+    [$} | NameRev] = lists:reverse(Name_CR),
+    list_to_atom(string:trim(lists:reverse(NameRev))).

--- a/src/hocon_scanner.xrl
+++ b/src/hocon_scanner.xrl
@@ -85,7 +85,7 @@ Duration            = {Digit}+(d|D|h|H|m|M|s|S|ms|MS)
 
 %% Variable
 Literal             = {Bool}|{Integer}|{Float}|{String}|{Unquoted}|{Percent}{Bytesize}|{Duration}
-Variable            = \$\{{Unquoted}+({WhiteSpace}*\|\|{WhiteSpace}*({Literal}))?\}
+Variable            = \$\{{Unquoted}\}
 
 Key                 = ({Unquoted}|{String})({WhiteSpace}*){KV}
 ObjectKey           = ({Unquoted}|{String})({WhiteSpace}*){


### PR DESCRIPTION
https://github.com/emqx/hocon/issues/11

In this change, we find `key` at a scanner level. Otherwise the parser would be hard to distinguish `key` from `string`. 
For example
```
a=foo
b=${a}bar"baz"
c=baz
```
the tokens for this HOCON would be
```
string = string string = variable string string string string = string
```
To parse this, we have to tell the parser that `string is key only when = operator follows`, which is hard to describe in yecc (because of shift/reduce conflicts).

By introducing `key` at a scanner level, now the tokens are
```
key string key variable string string string key string
```