### PR TITLE
feat(src): support look-forward variable subst, object and array concatenation

### DIFF
--- a/src/hocon.erl
+++ b/src/hocon.erl
@@ -40,6 +40,8 @@ load(Filename0, Ctx0) ->
              , fun scan/1
              , fun preparse/1
              , fun parse/1
+             , fun resolve/1
+             , fun concat/1
              , fun expand/1
              , fun transform/2
              ]).
@@ -49,6 +51,8 @@ binary(Binary) ->
              [ fun scan/1
              , fun preparse/1
              , fun parse/1
+             , fun resolve/1
+             , fun concat/1
              , fun expand/1
              , fun transform/2
              ]).
@@ -107,7 +111,7 @@ parse(Tokens) ->
 
 -spec(transform(config(), ctx()) -> {ok, config()}).
 transform(Config, Ctx) ->
-    try include(substitute(Config), Ctx) of
+    try include(Config, Ctx) of
         RootMap -> {ok, RootMap}
     catch
         error:Reason:St -> {error, {Reason,St}}
@@ -143,24 +147,147 @@ do_include(File, Ctx, Map) ->
             error({include_error, File, Reason})
     end.
 
-substitute(RootMap) ->
-    substitute(RootMap, RootMap).
-
-substitute(MapVal, RootMap) when is_map(MapVal) ->
-    maps:map(fun(_Key, Substrings) -> substitute(Substrings, RootMap) end, MapVal);
-substitute(Array, RootMap) when is_list(Array) ->
-    lists:map(fun(I) -> substitute(I, RootMap) end, Array);
-substitute({concat, Substrings}, RootMap) ->
-    iolist_to_binary(lists:map(fun(S) -> substitute(S, RootMap) end, Substrings));
-substitute({var, Name}, RootMap) ->
-    do_substitute(Name, RootMap);
-substitute(Value, _RootMap) -> Value.
-
-do_substitute(Varname, RootMap) ->
-    case nested_get(paths(Varname), RootMap) of
-        undefined -> error({variable_not_found, Varname});
-        Val -> substitute(Val, RootMap)
+-spec resolve(list()) -> {ok, list()} | {error, any()}.
+resolve(KVList) ->
+    try
+        {ok, do_resolve(KVList)}
+    catch
+        error:Reason:St -> {error, {Reason,St}}
     end.
+
+do_resolve(KVList) ->
+    case do_resolve(KVList, [], [], KVList) of
+        skip ->
+            KVList;
+        {resolved, Resolved} ->
+            do_resolve(Resolved);
+        {unresolved, Unresolved} ->
+            error({unresolved, lists:flatten(Unresolved)})
+    end.
+do_resolve([], _Acc, [], _RootKVList) ->
+    skip;
+do_resolve([], _Acc, Unresolved, _RootKVList) ->
+    {unresolved, Unresolved};
+do_resolve([V|More], Acc, Unresolved, RootKVList) ->
+    case do_resolve(V, [], [], RootKVList) of
+        {resolved, Resolved} ->
+            {resolved, lists:reverse(Acc, [Resolved|More])};
+        {unresolved, Var} ->
+            do_resolve(More, [V| Acc], [Var| Unresolved], RootKVList);
+        skip ->
+            do_resolve(More, [V| Acc], Unresolved, RootKVList)
+    end;
+do_resolve({concat, List}, _Acc, _Unresolved, RootKVList) when is_list(List) ->
+    case do_resolve(List, [], [], RootKVList) of
+        {resolved, Resolved} ->
+            {resolved, {concat, Resolved}};
+        {unresolved, Var} ->
+            {unresolved, Var};
+        skip ->
+            skip
+    end;
+do_resolve({var, Var}, _Acc, _Unresolved, RootKVList) ->
+    case lookup(paths(Var), RootKVList) of
+        notfound ->
+            {unresolved, Var};
+        ResolvedValue ->
+            {resolved, ResolvedValue}
+    end;
+do_resolve({Object}, _Acc, _Unresolved, RootKVList) when is_list(Object) ->
+    case do_resolve(Object, [], [], RootKVList) of
+        {resolved, Resolved} ->
+            {resolved, {Resolved}};
+        {unresolved, Var} ->
+            {unresolved, Var};
+        skip ->
+            skip
+    end;
+do_resolve({Key, Value}, _Acc, _Unresolved, RootKVList) ->
+    case do_resolve(Value, [], [], RootKVList) of
+        {resolved, Resolved} ->
+            {resolved, {Key, Resolved}};
+        {unresolved, Var} ->
+            {unresolved, Var};
+        skip ->
+            skip
+    end;
+do_resolve(_Constant, _Acc, _Unresolved, _RootKVList) ->
+    skip.
+
+is_resolved(KV) ->
+    case do_resolve(KV, [], [], []) of
+        skip ->
+            true;
+        _ ->
+            false
+    end.
+
+lookup(Var, KVList) ->
+    lookup(Var, KVList, notfound).
+
+lookup(Var, {concat, List}, ResolvedValue) ->
+    lookup(Var, List, ResolvedValue);
+lookup([Var], [{Var, Value} = KV|More], ResolvedValue) ->
+    case is_resolved(KV) of
+        true ->
+            lookup([Var], More, Value);
+        false ->
+            lookup([Var], More, ResolvedValue)
+    end;
+lookup([Path|MorePath] = Var, [{Path, Value}|More], ResolvedValue) ->
+    lookup(Var, More, lookup(MorePath, Value, ResolvedValue));
+lookup(Var, [{List}|More], ResolvedValue) ->
+    lookup(Var, More, lookup(Var, List, ResolvedValue));
+lookup(Var, [_Other|More], ResolvedValue) ->
+    lookup(Var, More, ResolvedValue);
+lookup(_Var, [], ResolvedValue) ->
+    ResolvedValue.
+
+-spec concat(list()) -> {ok, list()} | {error, any()}.
+concat(List) ->
+    try
+        {ok, iter_over_list_for_concat(List)}
+    catch
+        error:Reason:St -> {error, {Reason,St}}
+    end.
+
+iter_over_list_for_concat(List) when is_list(List) ->
+    lists:map(fun (E) -> verify_concat(E) end, List).
+
+verify_concat({concat, Concat}) ->
+    do_concat(Concat);
+verify_concat({Key, Value}) ->
+    {Key, verify_concat(Value)};
+verify_concat(Other) ->
+    Other.
+
+do_concat(Concat) ->
+    do_concat(Concat, []).
+
+% empty object ( a={} )
+do_concat([], [{}]) ->
+    {[]};
+do_concat([], [Object| _Objects] = Acc) when is_tuple(Object) ->
+    {lists:reverse(Acc)};
+do_concat([], [String| _Strings] = Acc) when is_binary(String) ->
+    iolist_to_binary(lists:reverse(Acc));
+do_concat([], [Array| _Arrays] = Acc) when is_list(Array) ->
+    lists:append(lists:reverse(Acc));
+do_concat([], [Acc]) ->
+    Acc;
+do_concat([], Acc) ->
+    lists:reverse(Acc);
+
+do_concat([Array| More], Acc) when is_list(Array) ->
+    do_concat(More, [iter_over_list_for_concat(Array)| Acc]);
+do_concat([{Object}| More], Acc)  when is_list(Object) ->
+    do_concat(More, lists:foldl(fun(KV, A) -> [verify_concat(KV)| A] end, Acc, Object));
+do_concat([String| More], Acc)  when is_binary(String) ->
+    do_concat(More, [String| Acc]);
+do_concat([{concat, Concat}|More], Acc) ->
+    do_concat([do_concat(Concat)|More], Acc);
+do_concat([Other|More], Acc) ->
+    do_concat(More, [Other|Acc]).
 
 expand({Members}) ->
     expand(Members);
@@ -192,23 +319,22 @@ nested_put([Key|Paths], Val, Map) ->
 merge(Key, Val, Map) when is_map(Val) ->
     case maps:find(Key, Map) of
         {ok, MVal} when is_map(MVal) ->
-            maps:put(Key, maps:merge(MVal, Val), Map);
+            maps:put(Key, do_deep_merge(MVal, Val), Map);
         _Other -> maps:put(Key, Val, Map)
     end;
 merge(Key, Val, Map) -> maps:put(Key, Val, Map).
 
-nested_get(Key, Map) ->
-    nested_get(Key, Map, undefined).
-
-nested_get([Key], Map, Default) ->
-    maps:get(Key, Map, Default);
-nested_get([Key|More], Map, Default) ->
-    case maps:find(Key, Map) of
-        {ok, MVal} when is_map(MVal) ->
-            nested_get(More, MVal, Default);
-        {ok, _Val} -> Default;
-        error -> Default
-    end.
+do_deep_merge(M1, M2) when is_map(M1), is_map(M2) ->
+    maps:fold(fun(K, V2, Acc) ->
+        case Acc of
+            #{K := V1} ->
+                Acc#{K => do_deep_merge(V1, V2)};
+            _ ->
+                Acc#{K => V2}
+        end
+              end, M1, M2);
+do_deep_merge(_, Override) ->
+    Override.
 
 pipeline(Input, Ctx, [Fun | Steps]) ->
     Result = case is_function(Fun, 1) of

--- a/src/hocon_scanner.xrl
+++ b/src/hocon_scanner.xrl
@@ -40,6 +40,7 @@ Ignored             = {WhiteSpace}|{NewLine}|{Comment}
 
 %% Punctuator
 Punctuator          = [{}\[\],:=]
+TrailingComma       = ,({Ignored})*}|,({Ignored})*]
 
 %% Bool
 Bool                = true|false|on|off
@@ -84,6 +85,7 @@ Rules.
 
 {Ignored}         : skip_token.
 {Punctuator}      : {token, {list_to_atom(string:trim(TokenChars)), TokenLine}}.
+{TrailingComma}   : {skip_token, string:trim(TokenChars, leading, ",")}.
 {Bool}            : {token, {bool, TokenLine, bool(TokenChars)}}.
 {Unquoted}        : {token, maybe_include(TokenChars, TokenLine)}.
 {Integer}         : {token, {integer, TokenLine, list_to_integer(TokenChars)}}.

--- a/src/hocon_scanner.xrl
+++ b/src/hocon_scanner.xrl
@@ -42,8 +42,8 @@ Ignored             = {WhiteSpace}|{NewLine}|{Comment}
 Punctuator          = [{}\[\],:=]
 TrailingComma       = ,({Ignored})*}|,({Ignored})*]
 
-%% Bool
-Bool                = true|false|on|off
+%% Null
+Null               = null
 
 %% Unquoted String
 Letter              = [A-Za-z]
@@ -60,7 +60,7 @@ Integer             = {Sign}?({Digit}+)
 %% Float
 Fraction            = \.{Digit}+
 Exponent            = [eE]{Sign}?{Digit}+
-Float               = {Integer}{Fraction}|{Integer}{Fraction}{Exponent}
+Float               = {Integer}?{Fraction}|{Integer}{Fraction}{Exponent}
 
 %% String
 Hex                 = [0-9A-Fa-f]
@@ -87,9 +87,10 @@ Rules.
 {Punctuator}      : {token, {list_to_atom(string:trim(TokenChars)), TokenLine}}.
 {TrailingComma}   : {skip_token, string:trim(TokenChars, leading, ",")}.
 {Bool}            : {token, {bool, TokenLine, bool(TokenChars)}}.
+{Null}            : {token, {null, TokenLine}}.
 {Unquoted}        : {token, maybe_include(TokenChars, TokenLine)}.
 {Integer}         : {token, {integer, TokenLine, list_to_integer(TokenChars)}}.
-{Float}           : {token, {float, TokenLine, list_to_float(TokenChars)}}.
+{Float}           : {token, {float, TokenLine, to_float(TokenChars)}}.
 {String}          : {token, {string, TokenLine, iolist_to_binary(unquote(TokenChars))}}.
 {MultilineString} : {token, {string, TokenLine, iolist_to_binary(unquote(TokenChars))}}.
 {Bytesize}        : {token, {bytesize, TokenLine, bytesize(TokenChars)}}.
@@ -147,3 +148,6 @@ duration(Val, "ms") -> Val.
 var_ref_name("${" ++ Name_CR) ->
     [$} | NameRev] = lists:reverse(Name_CR),
     list_to_atom(string:trim(lists:reverse(NameRev))).
+
+to_float("." ++ Fraction) -> to_float("0." ++ Fraction);
+to_float(Str) -> list_to_float(Str).

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -30,7 +30,7 @@ sample_files_test_() ->
 test_file_load("cycle"++_, F) ->
     ?assertMatch({error, {{include_error, _, _}, _}}, hocon:load(F));
 test_file_load("test13-reference-bad-substitutions", F) ->
-    ?assertMatch({error, {{variable_not_found,"b"}, _}}, hocon:load(F));
+    ?assertMatch({error, {{unresolved,[b]}, _}}, hocon:load(F));
 test_file_load("test07", F) ->
     ?assertMatch({error, {{include_error,_, enoent}, _}}, hocon:load(F));
 test_file_load("test08", F) ->
@@ -38,6 +38,78 @@ test_file_load("test08", F) ->
 test_file_load(_Name, F) ->
     ?assertMatch({ok, _}, hocon:load(F)).
 
+commas_test_() ->
+    [ ?_assertEqual(binary("a=[1,2,3]"), binary("a=[1,2,3,]"))
+    , ?_assertEqual(binary("a=[1,2,3]"), binary("a=[1\n2\n3]"))
+    , ?_assertError(_, binary("a=[1,2,3,,]"))
+    , ?_assertError(_, binary("a=[,1,2,3]"))
+    , ?_assertError(_, binary("a=[1,,2,3]"))
+    , ?_assertEqual(binary("a={b=1, c=2}"), binary("a={b=1, c=2,}"))
+    , ?_assertEqual(binary("a={b=1, c=2}"), binary("a={b=1\nc=2}"))
+    , ?_assertError(_, binary("a={b=1,c=2,,}"))
+    , ?_assertError(_, binary("a={,b=1,c=2}"))
+    , ?_assertError(_, binary("a={b=1,,c=2}"))
+    ].
+
+object_merging_test_() ->
+    [ ?_assertEqual(binary("a={b=1, c=2}"), binary("a={b=1}, a={c=2}"))
+    , ?_assertEqual(binary("a={b=1, c=2}"), binary("a={b=1, c=1}, a={c=2}"))
+    , ?_assertEqual(binary("a={c=2}"), binary("a={b=1, c=1}, a=a, a={c=2}"))
+    ].
+
+unquoted_test_() ->
+    [ ?_assertEqual(#{a => true}, binary("a=true"))
+    , ?_assertEqual(#{a => false}, binary("a=false"))
+    , ?_assertEqual(#{a => null}, binary("a=null"))
+    ].
+
+multiline_string_test_() ->
+    [].
+
+array_concat_test_() ->
+    [ ?_assertEqual(#{a => [1,2,3,4]}, binary("a=[1, 2] [3, 4]"))
+    , ?_assertEqual(#{a => [1,2,3,4]}, binary("a=[1, 2][3, 4]"))
+    , ?_assertEqual(#{a => [1,2,3,4]}, binary("a=[1, 2,][3, 4]"))
+    , ?_assertEqual(#{a => [1,2,3,4]}, binary("a=[1, 2, ][3, 4]"))
+    , ?_assertEqual(#{a => [1,2,3,4]}, binary("a=[1, 2, \n][3, 4]"))
+    , ?_assertEqual(#{x => [1,2],y => [1,2,1,2]}, binary("x=[1,2],y=${x}[1,2]"))
+    , ?_assertEqual(#{x => [1,2],y => [[1,2],[1,2]]}, binary("x=[1,2],y=[${x},[1,2]]"))
+    , ?_assertEqual(#{a => #{x => [1,2,<<"str">>,#{a => 1}]}}, binary("a={x=[1,2,str][{a=1}]}"))
+    , ?_assertEqual(#{z => [#{a => 1, b => 1}, #{c => 1}]}, binary("z=[{a=1}{b=1}, {c=1}]"))
+    , ?_assertEqual(#{x => #{a => 1, b => 1}}, binary("x={a=1} {b=${x.a}}"))
+    , ?_assertEqual(#{x => #{a => 1, b => 1}}, binary("x={a=${x.b}} {b=1}"))
+    , ?_assertEqual(#{x => #{a => 1, b => 1}}, binary("x={a=${x.b} b=1}"))
+    , ?_assertEqual(#{x => #{a => #{p => 1, q => 1}, b => 1}}, binary("x={a={p=${x.a.q}, q=${x.b}} b=1}"))
+    ].
+
+object_concat_test_() ->
+    [ ?_assertEqual(#{a => #{b => 1,c => 2}}, binary("a={b=1} {c=2}"))
+    , ?_assertEqual(#{a => #{b => 1,c => 2}}, binary("a={b=1}{c=2}"))
+    , ?_assertEqual(#{a => #{b => 1,c => 2}}, binary("a={b=1,}{c=2}"))
+    , ?_assertEqual(#{a => #{b => 1,c => 2},x => #{c => 2}}, binary("x={c=2},a={b=1,}${x}"))
+    , ?_assertEqual(#{a => #{b => 1,c => 2},x => #{c => 2}}, binary("x={c=2},a={b=1, }${x}"))
+    , ?_assertEqual(#{a => #{b => 1,c => 2},x => #{c => 2}}, binary("x={c=2},a={b=1,\n}${x}"))
+    , ?_assertEqual(#{a => #{x => 1,y => 2},b => #{x => 1,y => 2,z => 0}}, binary("a={x=1,y=2},b={x=0,y=0,z=0}${a}"))
+    , ?_assertEqual(#{a => #{x => 1,y => 2},b => #{x => 0,y => 0,z => 0}}, binary("a={x=1,y=2},b=${a}{x=0,y=0,z=0}"))
+    , ?_assertEqual(#{a => #{x => [1,2,#{a => 1}]}}, binary("a={x=[1,2,{a:1}]}"))
+    ].
+
+
+string_concat_test_() ->
+    [ ?_assertEqual(#{a => <<"foobar">>}, binary("a=foo\"bar\""))
+    , ?_assertEqual(#{a => <<"foobar">>, x => <<"foo">>}, binary("x=foo,a=${x}bar"))
+    ].
+
+float_point_test_() ->
+    [ ?_assertEqual(#{a => 0.5}, binary("a=0.5"))
+    , ?_assertEqual(#{a => 0.5}, binary("a=.5"))
+    , ?_assertEqual(#{a => 1.5}, binary("a=1.5"))
+    ].
+
+look_forward_test_() ->
+    [ ?_assertEqual(#{a => <<"x">>,b => <<"y">>,c => <<"xy">>}, binary("a=x,b=${c},c=\"y\", c=${a}${b}"))
+    , ?_assertEqual(#{a => <<"x">>,b => <<>>,c => <<"x">>}, binary("a=x,b=${c},c=\"\", c=${a}${b}"))
+    ].
 
 array_element_splice_test_() ->
     [ ?_assertEqual(#{}, binary(<<>>))


### PR DESCRIPTION
`look-forward variable substitution`
```
a = x
b = ${c}
c = ""
c = ${a}${b}
```
( this is #{a => <<"x">>,b => <<>>,c => <<"x">>})
`array concatenation`
```
a=[1, 2][3, 4]
```
( this is #{a => [1,2,3,4]})

`object concatenation`
```
a={b=1}{c=2}
```
( this is #{a => #{b => 1,c => 2})

Check tests for more examples.

