### PR TITLE
support proplist as output, which is interpretable by cuttlefish

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -110,5 +110,5 @@ mqtt {
 
 broker { }
 
-include "etc/node.conf"
+include "node.conf"
 

--- a/etc/emqx_auth_redis.conf
+++ b/etc/emqx_auth_redis.conf
@@ -1,0 +1,10 @@
+auth.redis {
+  type = single
+  server = "127.0.0.1:6379"
+  pool = 8
+  database = 0
+  auth_cmd = "HMGET mqtt_user:%u password"
+  password_hash = plain
+  super_cmd = "HGET mqtt_user:%u is_superuser"
+  acl_cmd = "HGETALL mqtt_acl:%u"
+}

--- a/priv/emqx_auth_redis.schema
+++ b/priv/emqx_auth_redis.schema
@@ -1,0 +1,139 @@
+%%-*- mode: erlang -*-
+%% emqx_auth_redis config mapping
+
+{mapping, "auth.redis.type", "emqx_auth_redis.server", [
+  {default, single},
+  {datatype, {enum, [single, sentinel, cluster]}}
+]}.
+
+{mapping, "auth.redis.server", "emqx_auth_redis.server", [
+  {default, "127.0.0.1:6379"},
+  {datatype, [string]}
+]}.
+
+{mapping, "auth.redis.sentinel", "emqx_auth_redis.server", [
+  {default, ""},
+  {datatype, string},
+  hidden
+]}.
+
+{mapping, "auth.redis.pool", "emqx_auth_redis.server", [
+  {default, 8},
+  {datatype, integer}
+]}.
+
+{mapping, "auth.redis.database", "emqx_auth_redis.server", [
+  {default, 0},
+  {datatype, integer}
+]}.
+
+{mapping, "auth.redis.password", "emqx_auth_redis.server", [
+  {default, ""},
+  {datatype, string},
+  hidden
+]}.
+
+{mapping, "auth.redis.ssl", "emqx_auth_redis.options", [
+  {default, off},
+  {datatype, flag}
+]}.
+
+{mapping, "auth.redis.cafile", "emqx_auth_redis.options", [
+  {default, ""},
+  {datatype, string}
+]}.
+
+{mapping, "auth.redis.certfile", "emqx_auth_redis.options", [
+  {default, ""},
+  {datatype, string}
+]}.
+
+{mapping, "auth.redis.keyfile", "emqx_auth_redis.options", [
+  {default, ""},
+  {datatype, string}
+]}.
+
+{translation, "emqx_auth_redis.options", fun(Conf) ->
+   Ssl = cuttlefish:conf_get("auth.redis.ssl", Conf, false),
+   case Ssl of
+       true ->
+            CA = cuttlefish:conf_get("auth.redis.cafile", Conf),
+            Cert = cuttlefish:conf_get("auth.redis.certfile", Conf),
+            Key = cuttlefish:conf_get("auth.redis.keyfile", Conf),
+            [{options, [{ssl_options, [{cacertfile, CA},
+                                       {certfile, Cert},
+                                       {keyfile, Key}]}]}];
+       _ -> [{options, []}]
+   end
+end}.
+
+{translation, "emqx_auth_redis.server", fun(Conf) ->
+  Fun = fun(S) ->
+    case string:split(S, ":", trailing) of
+      [Domain]       -> {Domain, 6379};
+      [Domain, Port] -> {Domain, list_to_integer(Port)}
+    end
+  end,
+  Servers = cuttlefish:conf_get("auth.redis.server", Conf),
+  Type = cuttlefish:conf_get("auth.redis.type", Conf),
+  Server = case Type of
+    single ->
+      {Host, Port} = Fun(Servers),
+      [{host, Host}, {port, Port}];
+    _ ->
+      S = string:tokens(Servers, ","),
+      [{servers, [Fun(S1) || S1 <- S]}]
+  end,
+  Pool = cuttlefish:conf_get("auth.redis.pool", Conf),
+  Passwd = cuttlefish:conf_get("auth.redis.password", Conf),
+  DB = cuttlefish:conf_get("auth.redis.database", Conf),
+  Sentinel = cuttlefish:conf_get("auth.redis.sentinel", Conf),
+  [{type, Type},
+   {pool_size, Pool},
+   {auto_reconnect, 1},
+   {database, DB},
+   {password, Passwd},
+   {sentinel, Sentinel}] ++ Server
+end}.
+
+{mapping, "auth.redis.query_timeout", "emqx_auth_redis.query_timeout", [
+  {default, ""},
+  {datatype, string}
+]}.
+
+{translation, "emqx_auth_redis.query_timeout", fun(Conf) ->
+  case cuttlefish:conf_get("auth.redis.query_timeout", Conf) of
+      "" -> infinity;
+      Duration ->
+          case cuttlefish_duration:parse(Duration, ms) of
+              {error, Reason} -> error(Reason);
+              Ms when is_integer(Ms) -> Ms
+          end
+  end
+end}.
+
+{mapping, "auth.redis.auth_cmd", "emqx_auth_redis.auth_cmd", [
+  {datatype, string}
+]}.
+
+{mapping, "auth.redis.password_hash", "emqx_auth_redis.password_hash", [
+  {datatype, string}
+]}.
+
+{mapping, "auth.redis.super_cmd", "emqx_auth_redis.super_cmd", [
+  {datatype, string}
+]}.
+
+{mapping, "auth.redis.acl_cmd", "emqx_auth_redis.acl_cmd", [
+  {datatype, string}
+]}.
+
+{translation, "emqx_auth_redis.password_hash", fun(Conf) ->
+  HashValue = cuttlefish:conf_get("auth.redis.password_hash", Conf),
+  case string:tokens(HashValue, ",") of
+    [Hash]           -> list_to_atom(Hash);
+    [Prefix, Suffix] -> {list_to_atom(Prefix), list_to_atom(Suffix)};
+    [Hash, MacFun, Iterations, Dklen] -> {list_to_atom(Hash), list_to_atom(MacFun), list_to_integer(Iterations), list_to_integer(Dklen)};
+    _                -> plain
+  end
+end}.

--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,9 @@
 
 {profiles,
  [{test,
-   [ {deps, [{proper, "1.3.0"}]}
+   [ {deps, [{proper, "1.3.0"},
+             {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.0.0"}}}
+            ]}
    , {extra_src_dirs, ["sample-configs"]}
    ]
   }]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,9 @@
 {"1.2.0",
-[{<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},0}]}.
+[{<<"cuttlefish">>,
+  {git,"https://github.com/emqx/cuttlefish",
+       {ref,"913f0bdf47f52c9d6339196c5b083539e9ddc93f"}},
+  0},
+ {<<"getopt">>,{pkg,<<"getopt">>,<<"1.0.1">>},0}]}.
 [
 {pkg_hash,[
  {<<"getopt">>, <<"C73A9FA687B217F2FF79F68A3B637711BB1936E712B521D8CE466B29CBF7808A">>}]},

--- a/src/hocon.erl
+++ b/src/hocon.erl
@@ -16,7 +16,7 @@
 
 -module(hocon).
 
--export([load/1, binary/1]).
+-export([load/1, load/2, binary/1]).
 -export([scan/1, parse/1, dump/2, dump/3]).
 -export([main/1]).
 
@@ -28,13 +28,44 @@
 main(Args) ->
     hocon_cli:main(Args).
 
+proplist(Map) when is_map(Map) ->
+    proplist(maps:iterator(Map), [], []).
+proplist(Iter, Path, Acc) ->
+    case maps:next(Iter) of
+        {K, M, I} when is_map(M) ->
+            Child = proplist(maps:iterator(M), [atom_to_list(K)| Path], []),
+            proplist(I, Path, lists:append(Child, Acc));
+        {K, [Bin|_More]=L, I} when is_binary(Bin) ->
+            NewList = [binary_to_list(B) || B <- L],
+            ReversedPath = lists:reverse([atom_to_list(K)| Path]),
+            proplist(I, Path, [{ReversedPath, NewList}| Acc]);
+        {K, Bin, I} when is_binary(Bin) ->
+            ReversedPath = lists:reverse([atom_to_list(K)| Path]),
+            proplist(I, Path, [{ReversedPath, binary_to_list(Bin)}| Acc]);
+        {K, V, I} ->
+            ReversedPath = lists:reverse([atom_to_list(K)| Path]),
+            proplist(I, Path, [{ReversedPath, V}| Acc]);
+        none ->
+            Acc
+    end.
+
 -spec(load(file:filename()) -> {ok, config()} | {error, term()}).
 load(Filename0) ->
+    load(Filename0, [{format, map}]).
+
+-spec(load(file:filename(), list()) -> {ok, config()} | {error, term()}).
+load(Filename0, Opts) ->
     Filename = filename:absname(Filename0),
     Ctx = stack_multiple_push([{path, '$root'}, {filename, Filename}], #{}),
     try
         Bytes = read(Filename),
-        {ok, do_binary(Bytes, Ctx)}
+        Map = do_binary(Bytes, Ctx),
+        case lists:keyfind(format, 1, Opts) of
+            {format, proplist} ->
+                {ok, proplist(Map)};
+            _ ->
+                {ok, Map}
+        end
     catch
         throw:Reason -> {error, Reason}
     end.

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -193,6 +193,27 @@ maybe_var_test_() ->
     , ?_assertEqual(#{}, binary(<<"x=${?y}${?z}">>))
     ].
 
+cuttlefish_proplist_test() ->
+    Schema = filename:absname("priv/emqx_auth_redis.schema"),
+    {ok, Proplist} = hocon:load("etc/emqx_auth_redis.conf", [{format, proplist}]),
+    ?assertEqual([{emqx_auth_redis,
+                   [{acl_cmd, "HGETALL mqtt_acl:%u"},
+                    {super_cmd, "HGET mqtt_user:%u is_superuser"},
+                    {auth_cmd, "HMGET mqtt_user:%u password"},
+                    {options, [{options, []}]},
+                    {server,
+                     [{type, single},
+                      {pool_size, 8},
+                      {auto_reconnect, 1},
+                      {database, 0},
+                      {password, []},
+                      {sentinel, []},
+                      {host, "127.0.0.1"},
+                      {port, 6379}]},
+                    {query_timeout, infinity},
+                    {password_hash, plain}]}],
+                 cuttlefish_generator:map(cuttlefish_schema:files([Schema]), Proplist)).
+
 binary(B) when is_binary(B) ->
     {ok, R} = hocon:binary(B),
     R;

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -26,7 +26,22 @@ sample_files_test_() ->
         BaseName = filename:basename(F, ".conf"),
         {BaseName, fun() -> test_file_load(BaseName, F) end}
      end || F <- filelib:wildcard(Wildcard)].
-
+%% include file() is not supported.
+test_file_load("file-include", F) ->
+    ?assertMatch({error, {scan_error, _}}, hocon:load(F));
+%% unquoted string starting by null is not allowed.
+%% Failure/Error: {error,function_clause,
+%%                        [{io_lib,write_string1,
+%%                             [unicode_as_unicode,<<"bar">>,34],
+%%                             [{file,"io_lib.erl"},{line,581}]},
+%%                         {io_lib,write_string,2,
+%%                             [{file,"io_lib.erl"},{line,553}]},
+%%                         {hocon_parser,yeccerror,1, ...
+test_file_load("test01", F) ->
+    ?assertError(_, hocon:load(F));
+%% do not allow quoted variable name.
+test_file_load("test02"++_, F) ->
+    ?assertMatch({error, {scan_error, _}}, hocon:load(F));
 test_file_load("cycle"++_, F) ->
     ?assertMatch({error, {cycle, _}}, hocon:load(F));
 test_file_load("test13-reference-bad-substitutions", F) ->


### PR DESCRIPTION
I found out that some `.schema` is not designed to be compatible with HOCON.

Let's take `emqx.schema` as an example:

https://github.com/emqx/emqx/blob/305918ec9e1d08a088f51ad2564201e3d3f3b936/priv/emqx.schema#L1169

Here, cuttlefish expects both `listener.tcp.$name` and `listener.tcp.$name.acceptors` to be a value. In HOCON, `listener.tcp.$name` cannot be both a value and an object simultaneously, so in this case, we have no way to create such HOCON file that could be interpretable by cuttlefish.

On the other hand, we have no difficulty with `emqx_auth_redis.schema`, which does not make use of the above contradictory assignment.