### PR TITLE
feat(hocon_schema): schema for single level fields

### DIFF
--- a/sample-schemas/demo_schema.erl
+++ b/sample-schemas/demo_schema.erl
@@ -9,6 +9,8 @@
 
 -export([structs/0, fields/1, translations/0, translation/1]).
 
+-define(FIELD(NAME, TYPE), fun(mapping) -> NAME; (type) -> TYPE; (_) -> undefined end).
+
 structs() -> [foo, "a.b", person, "id"].
 translations() -> ["app_foo"].
 
@@ -46,13 +48,10 @@ fields("j.k") ->
     ];
 
 fields(person) ->
-    [{id, fun(mapping) -> "person.id"; (type) -> "id"; (_) -> undefined end}];
+    [{id, ?FIELD("person.id", "id")}];
 
 fields("id") ->
-    [fun(mapping) -> "id";
-        (type) -> integer();
-        (_) -> undefined
-     end].
+    [?FIELD("id", integer())].
 
 translation("app_foo") ->
     [ {"range", fun range/1} ].

--- a/sample-schemas/demo_schema.erl
+++ b/sample-schemas/demo_schema.erl
@@ -9,7 +9,7 @@
 
 -export([structs/0, fields/1, translations/0, translation/1]).
 
-structs() -> [foo, "a.b"].
+structs() -> [foo, "a.b", person, "id"].
 translations() -> ["app_foo"].
 
 fields(foo) ->
@@ -43,8 +43,16 @@ fields("x.y") ->
 
 fields("j.k") ->
     [ {"some_int", fun priv_int/1}
-    ].
+    ];
 
+fields(person) ->
+    [{id, fun(mapping) -> "person.id"; (type) -> "id"; (_) -> undefined end}];
+
+fields("id") ->
+    [fun(mapping) -> "id";
+        (type) -> integer();
+        (_) -> undefined
+     end].
 
 translation("app_foo") ->
     [ {"range", fun range/1} ].
@@ -62,8 +70,7 @@ range(Conf) ->
             {Min, Max};
         _ ->
             throw("should be min < max")
-    end,
-    {Min, Max}.
+    end.
 
 endpoint(mapping) -> "app_foo.endpoint";
 endpoint(type) -> typerefl:ip4_address();

--- a/src/hocon.erl
+++ b/src/hocon.erl
@@ -256,7 +256,7 @@ do_concat([], _, []) ->
     nothing;
 do_concat([], MetaKey, [{#{metadata := MetaFirstElem}, _V} = F | _Fs] = Acc) when ?IS_FIELD(F) ->
     Metadata = hocon_util:do_deep_merge(MetaFirstElem, MetaKey),
-    case lists:all(fun (F) -> ?IS_FIELD(F) end, Acc) of
+    case lists:all(fun (F0) -> ?IS_FIELD(F0) end, Acc) of
         true ->
             #{type => object, value => lists:reverse(Acc), metadata => Metadata};
         false ->


### PR DESCRIPTION
Sometimes fields in hocon file many have only one level like:

```
{id: 123}
```

This PR adds the support for writing schema for the above example as:

```
structs() -> ["id"].
fields("id") ->
    [fun(mapping) -> "id";
        (type) -> integer();
        (_) -> undefined
     end].
```