### PR TITLE
Feat support map schema

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,7 +26,7 @@
 {profiles,
   [ {test,
     [ {deps, [ {proper, "1.3.0"}
-             , {cuttlefish, {git, "https://github.com/emqx/cuttlefish.git", {tag, "v3.3.4"}}}
+             , {cuttlefish, {git, "https://github.com/emqx/cuttlefish.git", {tag, "v3.3.5"}}}
              ]}
     , {extra_src_dirs, ["sample-configs", "sample-schemas", "_build/test/lib/cuttlefish/test"]}
     , {erl_opts, [{i, "_build/test/lib/cuttlefish/include"}]}]}

--- a/sample-schemas/demo_schema.erl
+++ b/sample-schemas/demo_schema.erl
@@ -12,7 +12,7 @@
 
 -export([structs/0, fields/1, translations/0, translation/1]).
 
--define(FIELD(NAME, TYPE), fun(mapping) -> NAME; (type) -> TYPE; (_) -> undefined end).
+-define(FIELD(NAME, TYPE), #{mapping => NAME, type => TYPE}).
 
 structs() -> [foo, "a.b", "b", person, "vm"].
 translations() -> ["app_foo"].

--- a/test/hocon_cli_tests.erl
+++ b/test/hocon_cli_tests.erl
@@ -170,4 +170,4 @@ regexp_vmargs(StdOut) ->
     Path.
 
 with_envs(Fun, Args, Envs) ->
-    hocon_schema:with_envs(Fun, Args, Envs).
+    hocon_test_lib:with_envs(Fun, Args, Envs).

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -1,3 +1,18 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
 -module(hocon_schema_tests).
 
 -include_lib("typerefl/include/types.hrl").
@@ -33,7 +48,7 @@ default_value_test() ->
                                    <<"field1">> => "foo"}}, Res).
 
 env_overide_test() ->
-    hocon_schema:with_envs(
+    with_envs(
       fun() ->
               Conf = "{\"bar.field1\": \"foo\"}",
               Res = check(Conf),
@@ -132,3 +147,70 @@ generate_compatibility_test() ->
     [{app_foo, C0}] = cuttlefish_generator:map({Translations, Mappings, []}, Conf),
     [{app_foo, C1}] = hocon_schema:generate(demo_schema, Hocon),
     ?assertEqual(lists:ukeysort(1, C0), lists:ukeysort(1, C1)).
+
+deep_get_test_() ->
+    F = fun(Str, Key, Param) -> {ok, M} = hocon:binary(Str, #{format => richmap}),
+                                hocon_schema:deep_get(Key, M, Param, undefined) end,
+    [ ?_assertEqual(1, F("a=1", "a", value))
+    , ?_assertMatch(#{line := 1}, F("a=1", "a", metadata))
+    , ?_assertEqual(1, F("a={b=1}", "a.b", value))
+    , ?_assertEqual(1, F("a={b=1}", ["a", "b"], value))
+    , ?_assertEqual(undefined, F("a={b=1}", "a.c", value))
+    ].
+
+deep_put_test_() ->
+    F = fun(Str, Key, Value, Param) -> {ok, M} = hocon:binary(Str, #{format => richmap}),
+                                       NewM = hocon_schema:deep_put(Key, Value, M, Param),
+                                       hocon_schema:deep_get(Key, NewM, Param, undefined) end,
+    [ ?_assertEqual(2, F("a=1", "a", 2, value))
+    , ?_assertEqual(2, F("a={b=1}", "a.b", 2, value))
+    , ?_assertEqual(#{x => 1}, F("a={b=1}", "a.b", #{x => 1}, value))
+    ].
+
+richmap_to_map_test_() ->
+    F = fun(Str) -> {ok, M} = hocon:binary(Str, #{format => richmap}),
+                    hocon_schema:richmap_to_map(M) end,
+    [ ?_assertEqual(#{<<"a">> => #{<<"b">> => 1}}, F("a.b=1"))
+    , ?_assertEqual(#{<<"a">> => #{<<"b">> => [1, 2, 3]}}, F("a.b = [1,2,3]"))
+    , ?_assertEqual(#{<<"a">> =>
+                      #{<<"b">> => [1, 2, #{<<"x">> => <<"foo">>}]}}, F("a.b = [1,2,{x=foo}]"))
+    ].
+
+
+env_test_() ->
+    F = fun (Str, Envs) ->
+                    {ok, M} = hocon:binary(Str, #{format => richmap}),
+                    {Mapped, _} = with_envs(fun hocon_schema:map/2, [demo_schema, M],
+                                            Envs ++ [{"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"}]),
+                    Mapped
+        end,
+    [ ?_assertEqual([{["app_foo", "setting"], "hi"}],
+                    F("foo.setting=hello", [{"EMQX_FOO__SETTING", "hi"}]))
+    , ?_assertEqual([{["app_foo", "setting"], "yo"}],
+                    F("foo.setting=hello", [{"EMQX_MY_OVERRIDE", "yo"}]))
+    , ?_assertEqual([{["app_foo", "numbers"], [4, 5, 6]}],
+                    F("foo.numbers=[1,2,3]", [{"EMQX_FOO__NUMBERS", "[4,5,6]"}]))
+    , ?_assertEqual([{["app_foo", "greet"], "hello"}],
+                    F("", [{"EMQX_FOO__GREET", "hello"}]))
+    ].
+
+translate_test_() ->
+    F = fun (Str) -> {ok, M} = hocon:binary(Str, #{format => richmap}),
+                     {Mapped, Conf} = hocon_schema:map(demo_schema, M),
+                     hocon_schema:translate(demo_schema, Conf, Mapped) end,
+    [ ?_assertEqual([{["app_foo", "range"], {1, 2}}],
+                    F("foo.min=1, foo.max=2"))
+    , ?_assertEqual([], F("foo.min=2, foo.max=1"))
+    ].
+
+nest_test_() ->
+    [ ?_assertEqual([{a, [{b, {1, 2}}]}],
+                    hocon_schema:nest([{["a", "b"], {1, 2}}]))
+    , ?_assertEqual([{a, [{b, 1}, {c, 2}]}],
+                    hocon_schema:nest([{["a", "b"], 1}, {["a", "c"], 2}]))
+    , ?_assertEqual([{a, [{b, 1}, {z, 2}]}, {x, [{a, 3}]}],
+                    hocon_schema:nest([{["a", "b"], 1}, {["a", "z"], 2}, {["x", "a"], 3}]))
+    ].
+
+with_envs(Fun, Envs) -> hocon_test_lib:with_envs(Fun, Envs).
+with_envs(Fun, Args, Envs) -> hocon_test_lib:with_envs(Fun, Args, Envs).

--- a/test/hocon_test_lib.erl
+++ b/test/hocon_test_lib.erl
@@ -1,0 +1,35 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(hocon_test_lib).
+
+-compile(export_all).
+
+with_envs(Fun, Envs) ->
+    with_envs(Fun, [], Envs).
+
+with_envs(Fun, Args, [{_Name, _Value} | _] = Envs) ->
+    set_envs(Envs),
+    try
+        apply(Fun, Args)
+    after
+        unset_envs(Envs)
+    end.
+
+set_envs([{_Name, _Value} | _] = Envs) ->
+    lists:map(fun ({Name, Value}) -> os:putenv(Name, Value) end, Envs).
+
+unset_envs([{_Name, _Value} | _] = Envs) ->
+    lists:map(fun ({Name, _}) -> os:unsetenv(Name) end, Envs).


### PR DESCRIPTION
    The idea of using function clauses for field schema is to promote
    reusable types. However from the observation, we have already started
    creating a lot of anonymous functions. i.e. FAILED.
    Now map is supported to declare a schema to be more clean.
    e.g. a schema can be as simple as: `#{type => string()}`.
    instead of having to write `fun(type) -> string(); (_) -> undefined end`

    NOTE: structs fields are still NOT to be nested.
    i.e. `structs()` is still to return a list of names,
    and then call `fields(Name)` to get fields.
    i.e. there is no strong argument to support
    `#{struct_name => [{field1, #{type => string()}}]}`