### PR TITLE
Feat cli user decide file names

### DIFF
--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -117,7 +117,12 @@ get(_ParsedArgs, []) ->
 get(ParsedArgs, [Query | _]) ->
     Schema = load_schema(ParsedArgs),
     Conf = load_conf(ParsedArgs),
-    {_, NewConf} = hocon_schema:map(Schema, Conf),
+    %% map only the desired root name
+    [RootName0 | _] = string:tokens(Query, "."),
+    RootName = hocon_schema:find_struct(Schema, RootName0),
+    %% do not log anything for `get` commands
+    DummyLogger = #{logger => fun(_, _) -> ok end},
+    {_, NewConf} = hocon_schema:map(Schema, Conf, [RootName], DummyLogger),
     ?STDOUT("~p", [hocon_schema:deep_get(Query, NewConf, value)]),
     stop_ok().
 

--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -50,8 +50,8 @@ cli_options() ->
     , {dest_file, $f, "dest_file", {string, "app"}, "the file name to write"}
     , {schema_file, $i, "schema_file", string, "the file name of schema module"}
     , {schema_module, $s, "schema_module", atom, "the name of schema module"}
-    , {conf_file, $c, "conf_file", string, "a cuttlefish conf file, multiple files allowed"}
-    , {log_level, $l, "log_level", {string, "notice"}, "log level for cuttlefish output"}
+    , {conf_file, $c, "conf_file", string, "hocon conf file, multiple files allowed"}
+    , {log_level, $l, "log_level", {string, "notice"}, "log level"}
     , {max_history, $m, "max_history", {integer, 3},
         "the maximum number of generated config files to keep"}
     , {verbose_env, $v, "verbose_env", {boolean, false}, "whether to log env overrides to stdout"}
@@ -85,7 +85,7 @@ main(Args) ->
                    _ -> notice
                end,
     logger:remove_handler(default),
-    logger:add_handler(cuttlefish, logger_std_h,
+    logger:add_handler(hocon_cli, logger_std_h,
         #{config => #{type => standard_error},
             formatter => {logger_formatter,
                 #{legacy_header => false,
@@ -129,7 +129,7 @@ get(ParsedArgs, [Query | _]) ->
 -spec generate([proplists:property()]) -> no_return().
 generate(ParsedArgs) ->
     case engage_hocon(ParsedArgs) of
-        %% this is nice and all, but currently all error paths of engage_cuttlefish end with
+        %% this is nice and all, but currently all error paths of engage_hocon end with
         %% stop_deactivate() hopefully factor that to be cleaner.
         error ->
             stop_deactivate();

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -228,12 +228,14 @@ map(Schema, Conf) ->
     RootNames = structs(Schema),
     map(Schema, Conf, RootNames, #{}).
 
--spec map(schema(), hocon:config(), [name()]) ->
+-spec map(schema(), hocon:config(), all | [name()]) ->
         {[proplists:property()], hocon:config()}.
+map(Schema, Conf, all) ->
+    map(Schema, Conf, structs(Schema));
 map(Schema, Conf, RootNames) ->
     map(Schema, Conf, RootNames, #{}).
 
--spec map(schema(), hocon:config(), [name()], opts()) ->
+-spec map(schema(), hocon:config(), all | [name()], opts()) ->
         {[proplists:property()], hocon:config()}.
 map(Schema, Conf0, RootNames, Opts0) ->
     EnvPrefix= case os:getenv("HOCON_ENV_OVERRIDE_PREFIX") of

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -29,6 +29,7 @@
 -export([check/2, check/3, check_plain/2, check_plain/3]).
 -export([deep_get/2, deep_get/3, deep_get/4, deep_put/3]).
 -export([richmap_to_map/1]).
+-export([find_struct/2]).
 
 -include("hoconsc.hrl").
 
@@ -128,6 +129,14 @@ translations(#{translations := Trs}) -> maps:keys(Trs).
 -spec translation(schema(), name()) -> [translation()].
 translation(Mod, Name) when is_atom(Mod) -> Mod:translation(Name);
 translation(#{translations := Trs}, Name) -> maps:get(Name, Trs).
+
+%% @doc Find struct name from a guess.
+find_struct(Schema, StructName) ->
+    Names = [{bin(N), N} || N <- structs(Schema)],
+    case lists:keyfind(bin(StructName), 1, Names) of
+        false -> throw({unknown_struct_name, StructName});
+        {_, N} -> N
+    end.
 
 %% @doc generates application env from a parsed .conf and a schema module.
 %% For example, one can set the output values by

--- a/test/hocon_cli_tests.erl
+++ b/test/hocon_cli_tests.erl
@@ -83,7 +83,18 @@ generate_basic() ->
                    {ok, Stdout} = cuttlefish_test_group_leader:get_output(),
                    {ok, [[{app_foo, Plist}]]} = file:consult(regexp_config(Stdout)),
                    ?assertEqual("yaa", proplists:get_value(setting, Plist))
+               end),
+    ?CAPTURING(begin
+                   with_envs(fun hocon_cli:main/1,
+                             [["-c", etc("demo-schema-example-1.conf"),
+                              "-s", "demo_schema", "-d", out(), "generate", "--verbose_env"]],
+                             [{"ZZZ_FOO__MIN", "42"}, {"ZZZ_FOO_MAX", "43"},
+                              {"HOCON_ENV_OVERRIDE_PREFIX", "ZZZ_"}]),
+                   {ok, Stdout} = cuttlefish_test_group_leader:get_output(),
+                   ?assertMatch(<<"ZZZ_FOO__MIN = \"42\" -> foo.min\n", _/binary>>,
+                                iolist_to_binary(Stdout))
                end).
+
 
 generate_vmargs() ->
     ?CAPTURING(begin
@@ -138,8 +149,8 @@ prune_test() ->
     Cli(),
     AppConfigs = lists:sort(filelib:wildcard("app.*.config", out())),
     VMArgs = lists:sort(filelib:wildcard("vm.*.args", out())),
-    ?_assert(length(AppConfigs) =:= 2),
-    ?_assert(length(VMArgs) =:= 2),
+    ?assertEqual(2, length(AppConfigs)),
+    ?assertEqual(2, length(VMArgs)),
 
     timer:sleep(1100),
     Cli(),

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -387,7 +387,7 @@ unknown_fields_test() ->
     ?assertThrow([{validation_error, #{reason := unknown_fields,
                                        unknown := [<<"name">>]}}],
                  begin
-                     {Mapped, _} = hocon_schema:map(demo_schema, M),
+                     {Mapped, _} = hocon_schema:map(demo_schema, M, all),
                      Mapped
                  end).
 

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -464,3 +464,7 @@ check_return_atom_keys(Sc, Input) ->
     {ok, Map} = hocon:binary(Input),
     hocon_schema:check_plain(Sc, Map, #{atom_key => true}).
 
+find_struct_test() ->
+    ?assertEqual(foo, hocon_schema:find_struct(demo_schema, "foo")),
+    ?assertThrow({unknown_struct_name, "noexist"},
+                 hocon_schema:find_struct(demo_schema, "noexist")).


### PR DESCRIPTION
Prior to this PR, the hocon_cli's `generate` command prints `run_erl` boot command args to stdio and expect Erlang node's boot script to capture it and use it n `run_erl`.
The main reason I believe was that the `generate` command takes a system time and use it as a part of the generated file names. However the disadvantages of this approach are:
* Logs have to be printed to stderr
* Not shellcheck friendly as the captured stdout line has spaces, and must be split when used as `run erl`

Now the node boot script is forced to decide the next (new) name of the files to be generated by calling the `now_time` command.