### PR TITLE
chore(typerefl): Don't include a private header

### DIFF
--- a/src/hocon_schema_builtin.erl
+++ b/src/hocon_schema_builtin.erl
@@ -17,7 +17,6 @@
 -module(hocon_schema_builtin).
 
 -include_lib("typerefl/include/types.hrl").
--include_lib("typerefl/src/typerefl_int.hrl").
 
 -include("hoconsc.hrl").
 


### PR DESCRIPTION
This header contains some internal definitions that can change in the future without notice.