### PR TITLE
opts atom_key and return_plain not working for hocon_schema:map/4

### DIFF
--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -283,8 +283,7 @@ do_check(Schema, Conf, Opts0, RootNames) ->
     Opts = maps:merge(#{nullable => false}, Opts0),
     %% discard mappings for check APIs
     {_DiscardMappings, NewConf} = map(Schema, Conf, RootNames, Opts),
-    maybe_covert_keys_to_atom(
-        maybe_convert_to_plain_map(NewConf, Opts), Opts).
+    NewConf.
 
 maybe_convert_to_plain_map(Conf, #{is_richmap := true, return_plain := true}) ->
     richmap_to_map(Conf);
@@ -333,7 +332,8 @@ map(Schema, Conf, RootNames, Opts0) ->
     {Mapped, NewConf} = lists:foldl(F, {[], Conf}, RootNames),
     ok = assert_no_error(Schema, Mapped),
     ok = assert_integrity(Schema, NewConf, Opts),
-    {Mapped, NewConf}.
+    {Mapped, maybe_covert_keys_to_atom(
+                maybe_convert_to_plain_map(NewConf, Opts), Opts)}.
 
 %% Assert no dot in root struct name.
 %% This is because the dot will cause root name to be splited,

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -294,18 +294,26 @@ atom_key_array_test() ->
           },
     Conf = "arr = [{id = 1}, {id = 2}]",
     {ok, PlainMap} = hocon:binary(Conf, #{}),
-    ?assertEqual(#{arr => [#{id => 1}, #{id => 2}]},
-                 hocon_schema:check_plain(Sc, PlainMap, #{atom_key => true})).
-return_plain_test() ->
+    [ ?assertEqual(#{arr => [#{id => 1}, #{id => 2}]},
+            hocon_schema:check_plain(Sc, PlainMap, #{atom_key => true}))
+    , ?assertMatch({_, #{arr := [#{id := 1}, #{id := 2}]}},
+            hocon_schema:map(Sc, PlainMap, all, #{is_richmap => false, atom_key => true}))
+    ].
+
+return_plain_test_() ->
     Sc = #{structs => [?VIRTUAL_ROOT],
            fields => [ {metadata, hoconsc:t(string())}
                      , {type, hoconsc:t(string())}
                      , {value, hoconsc:t(string())}
                      ]},
     StrConf = "type=t, metadata=m, value=v",
-    {ok, M} = hocon:binary(StrConf, #{format => richmap}),
-    ?assertMatch(#{metadata := "m", type := "t", value := "v"},
-        hocon_schema:check(Sc, M, #{atom_key => true, return_plain => true})).
+    {ok, Conf} = hocon:binary(StrConf, #{format => richmap}),
+    Opts = #{atom_key => true, return_plain => true},
+    [ ?_assertMatch(#{metadata := "m", type := "t", value := "v"},
+            hocon_schema:check(Sc, Conf, Opts))
+    , ?_assertMatch({_, #{metadata := "m", type := "t", value := "v"}},
+            hocon_schema:map(Sc, Conf, all, Opts))
+    ].
 
 validator_test() ->
     Sc = #{structs => [?VIRTUAL_ROOT],


### PR DESCRIPTION
Move the handling of options for `atom_key` and `return_plain` into `hocon_schema:map/4`.