### PR TITLE
feat(hocon_schema): add hocon_schema:map_translate/3

### DIFF
--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -26,17 +26,14 @@
 
 -export([map/2, map/3, map/4]).
 -export([translate/3]).
+-export([nest/1]).
 -export([generate/2, generate/3]).
 -export([check/2, check/3, check_plain/2, check_plain/3, check_plain/4]).
 -export([deep_get/2, deep_get/3, deep_get/4, deep_put/3]).
--export([richmap_to_map/1, get_value/2]).
+-export([richmap_to_map/1, atom_key_map/1, get_value/2]).
 -export([find_struct/2]).
 
 -include("hoconsc.hrl").
-
--ifdef(TEST).
--export([nest/1]).
--endif.
 
 -export_type([ name/0
              , typefunc/0

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -26,14 +26,17 @@
 
 -export([map/2, map/3, map/4]).
 -export([translate/3]).
--export([nest/1]).
--export([generate/2, generate/3]).
+-export([generate/2, generate/3, map_translate/3]).
 -export([check/2, check/3, check_plain/2, check_plain/3, check_plain/4]).
 -export([deep_get/2, deep_get/3, deep_get/4, deep_put/3]).
--export([richmap_to_map/1, atom_key_map/1, get_value/2]).
+-export([richmap_to_map/1, get_value/2]).
 -export([find_struct/2]).
 
 -include("hoconsc.hrl").
+
+-ifdef(TEST).
+-export([nest/1]).
+-endif.
 
 -export_type([ name/0
              , typefunc/0
@@ -165,9 +168,14 @@ generate(Schema, Conf) ->
     generate(Schema, Conf, #{}).
 
 generate(Schema, Conf, Opts) ->
+    {Mapped, _NewConf} = map_translate(Schema, Conf, Opts),
+    Mapped.
+
+-spec(map_translate(schema(), hocon:config(), opts()) -> [proplists:property()]).
+map_translate(Schema, Conf, Opts) ->
     {Mapped, NewConf} = map(Schema, Conf, all, Opts),
     Translated = translate(Schema, NewConf, Mapped),
-    nest(Translated).
+    {nest(Translated), NewConf}.
 
 %% @private returns a nested proplist with atom keys
 -spec(nest([proplists:property()]) -> [proplists:property()]).

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -171,7 +171,8 @@ generate(Schema, Conf, Opts) ->
     {Mapped, _NewConf} = map_translate(Schema, Conf, Opts),
     Mapped.
 
--spec(map_translate(schema(), hocon:config(), opts()) -> [proplists:property()]).
+-spec(map_translate(schema(), hocon:config(), opts()) ->
+    {[proplists:property()], hocon:config()}).
 map_translate(Schema, Conf, Opts) ->
     {Mapped, NewConf} = map(Schema, Conf, all, Opts),
     Translated = translate(Schema, NewConf, Mapped),

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -170,6 +170,9 @@ generate_compatibility_test() ->
 
     [{app_foo, C0}] = cuttlefish_generator:map({Translations, Mappings, []}, Conf),
     [{app_foo, C1}] = hocon_schema:generate(demo_schema, Hocon),
+    {[{app_foo, C1}], Conf1} = hocon_schema:map_translate(demo_schema, Hocon, #{}),
+    ?assertMatch(#{<<"foo">> := #{<<"max">> := 2, <<"min">> := 1, <<"setting">> := "val"}},
+        hocon_schema:richmap_to_map(Conf1)),
     ?assertEqual(lists:ukeysort(1, C0), lists:ukeysort(1, C1)).
 
 deep_get_test_() ->


### PR DESCRIPTION
Sometimes one may want to generate the config and also return the mapped config.

For example when updating the config, I want to use the following code to generate a hocon config,
apply the app envs, and also save the mapped config in map() format:

```
{AppEnvs, MappedConf} = hocon_schema:map(emqx_schema, Conf, all, #{}),
Translated = hocon_schema:translate(emqx_schema, MappedConf, AppEnvs),
lists:foreach(fun({AppName, Envs}) ->
        [application:set_env(AppName, Par, Val) || {Par, Val} <- Envs]
    end, hocon_schema:nest(Translated)),
emqx_config:put(hocon_schema:richmap_to_map(MappedConf))
```

We can export the `hocon_schema:nest/1` to allow this.