### PR TITLE
fix(parser): delete trailing comma after token scan

### DIFF
--- a/etc/trailing-comma.conf
+++ b/etc/trailing-comma.conf
@@ -3,3 +3,7 @@ a: [
     # {}
     {c:2}
 ]
+b: [
+c,
+d,# this is a comment
+]

--- a/src/hocon.erl
+++ b/src/hocon.erl
@@ -98,6 +98,7 @@ binary(Binary, Opts) ->
 do_binary(Binary, Ctx) ->
     hocon_util:pipeline(Binary, Ctx,
                        [ fun hocon_token:scan/2
+                       , fun hocon_token:rm_trailing_comma/1
                        , fun hocon_token:trans_key/1
                        , fun hocon_token:parse/2
                        , fun hocon_token:include/2

--- a/src/hocon_scanner.xrl
+++ b/src/hocon_scanner.xrl
@@ -40,7 +40,6 @@ Ignored             = {WhiteSpace}|{NewLine}|{Comment}
 
 %% Punctuator
 Punctuator          = [{}\[\],:=]
-TrailingComma       = ,({WhiteSpace}|{NewLine})*}|,({WhiteSpace}|{NewLine})*]
 
 %% Null
 Null               = null
@@ -89,7 +88,6 @@ Rules.
 
 {Ignored}         : skip_token.
 {Punctuator}      : {token, {list_to_atom(string:trim(TokenChars)), TokenLine}}.
-{TrailingComma}   : {skip_token, string:trim(TokenChars, leading, ",")}.
 {Bool}            : {token, {bool, TokenLine, bool(TokenChars)}}.
 {Null}            : {token, {null, TokenLine, null}}.
 {Unquoted}        : {token, maybe_include(TokenChars, TokenLine)}.

--- a/src/hocon_token.erl
+++ b/src/hocon_token.erl
@@ -16,7 +16,7 @@
 
 -module(hocon_token).
 
--export([read/1, scan/2, trans_key/1, parse/2, include/2]).
+-export([read/1, scan/2, trans_key/1, rm_trailing_comma/1, parse/2, include/2]).
 -export([value_of/1]).
 
 -export_type([boxed/0, inbox/0]).
@@ -56,6 +56,17 @@ scan(Input, Ctx) when is_list(Input) ->
         {error, {Line, _Mod, ErrorInfo}, _} ->
             scan_error(Line, hocon_scanner:format_error(ErrorInfo), Ctx)
     end.
+
+rm_trailing_comma(Tokens) ->
+    rm_trailing_comma(Tokens, []).
+
+rm_trailing_comma([], Acc) -> lists:reverse(Acc);
+rm_trailing_comma([{',', _}, {'}', _} = Cr | More], Acc) ->
+    rm_trailing_comma(More, [Cr | Acc]);
+rm_trailing_comma([{',', _}, {']', _} = Sr | More], Acc) ->
+    rm_trailing_comma(More, [Sr | Acc]);
+rm_trailing_comma([Other | More], Acc) ->
+    rm_trailing_comma(More, [Other | Acc]).
 
 %% Due to the lack of a splicable value terminal token,
 %% the parser would have to look-ahead the second token

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -135,7 +135,8 @@ commas_test_() ->
     ].
 
 trailing_comma_test_() ->
-    [ ?_assertEqual({ok, #{<<"a">> => [#{<<"b">> => 1}, #{<<"c">> => 2}]}},
+    [ ?_assertEqual({ok, #{<<"a">> => [#{<<"b">> => 1}, #{<<"c">> => 2}],
+                           <<"b">> => [<<"c">>, <<"d">>]}},
                     hocon:load("etc/trailing-comma.conf"))
     ].
 


### PR DESCRIPTION
fixes #98 
having `}` or `]` in comment affects tokeniser,
and the fix in #99 causes syntax error when trailing comma is followed by a comment.