### PR TITLE
Refactor refine error logs

### DIFF
--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -125,7 +125,7 @@ get(_ParsedArgs, []) ->
     stop_deactivate();
 get(ParsedArgs, [Query | _]) ->
     Schema = load_schema(ParsedArgs),
-    Conf = load_conf(ParsedArgs, fun logger_for_get/3),
+    Conf = load_conf(ParsedArgs, fun log_for_get/3),
     %% map only the desired root name
     [RootName0 | _] = string:tokens(Query, "."),
     RootName = hocon_schema:find_struct(Schema, RootName0),
@@ -318,10 +318,10 @@ log(Level, Fmt, Args) ->
     logger:Level(Fmt, Args).
 
 %% log to stderr for 'get' command
-logger_for_get(L, Fmt, Args) when L =:= debug orelse L =:= info ->
+log_for_get(L, Fmt, Args) when L =:= debug orelse L =:= info ->
     case os:getenv("DEBUG") of
-        "1" -> ?STDERR(Fmt, Args);
+        "1" -> ?STDERR("[~p]: " ++ Fmt, [L | Args]);
         _ -> ok
     end;
-logger_for_get(_, Fmt, Args) ->
-    ?STDERR(Fmt, Args).
+log_for_get(L, Fmt, Args) ->
+    ?STDERR("[~p]: " ++ Fmt, [L | Args]).

--- a/src/hocon_token.erl
+++ b/src/hocon_token.erl
@@ -238,10 +238,10 @@ parse_error(Line, ErrorInfo, Ctx) ->
 format_error(Line, ErrorInfo, #{filename := [undefined]}) ->
     unicode:characters_to_binary(
             [ErrorInfo,
-             io_lib:format(" at_line ~w.",
+             io_lib:format(" line_number ~w",
                            [Line])]);
 format_error(Line, ErrorInfo, Ctx) ->
     unicode:characters_to_binary(
         [ErrorInfo,
-         io_lib:format(" in_file ~p at_line ~w.",
-                       [hd(hocon_util:get_stack(filename, Ctx)), Line])]).
+         io_lib:format(" line_number ~w in_file ~s",
+                       [Line, hd(hocon_util:get_stack(filename, Ctx))])]).


### PR DESCRIPTION
in syntax, scan, parse error messages, log line number before the filename.
also removed filename quotes (changed from `~p` to `~s`)
