### PR TITLE
chore(typerefl): Bump version to 0.8.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {minimum_otp_vsn, "21.0"}.
 
 {deps, [ {getopt, "1.0.1"}
-       , {typerefl, {git, "https://github.com/k32/typerefl.git", {tag, "0.7.0"}}}
+       , {typerefl, {git, "https://github.com/k32/typerefl.git", {tag, "0.8.0"}}}
        ]}.
 
 {edoc_opts, [{preprocess, true}]}.


### PR DESCRIPTION
Add support for type surrogates, e.g.:

```
-typerefl_surrogate({{unicode, charlist, 0}, typerefl, unicode_charlist}).
```