### PR TITLE
feat(hocon_schema): support set array value using env

### DIFF
--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -611,9 +611,9 @@ read_hocon_val(Value) ->
     end.
 
 read_informal_hocon_val(Value) ->
-    BoxedVal = "virtual_root=" ++ Value,
+    BoxedVal = "fake_key=" ++ Value,
     {ok, HoconVal} = hocon:binary(BoxedVal, #{}),
-    maps:get(<<"virtual_root">>, HoconVal).
+    maps:get(<<"fake_key">>, HoconVal).
 
 apply_env(_Ns, [], _RootName, Conf, _Opts) -> Conf;
 apply_env(Ns, [{VarName, V} | More], RootName, Conf, Opts) ->

--- a/test/hocon_cli_tests.erl
+++ b/test/hocon_cli_tests.erl
@@ -105,8 +105,8 @@ generate_with_env_logging_test() ->
                              [{"ZZZ_FOO__MIN", "42"}, {"ZZZ_FOO__MAX", "43"},
                               {"HOCON_ENV_OVERRIDE_PREFIX", "ZZZ_"}]),
                    {ok, Stdout} = cuttlefish_test_group_leader:get_output(),
-                   ?assertEqual([<<"ZZZ_FOO__MAX = \"43\" -> foo.max">>,
-                                 <<"ZZZ_FOO__MIN = \"42\" -> foo.min">>],
+                   ?assertEqual([<<"ZZZ_FOO__MAX = 43 -> foo.max">>,
+                                 <<"ZZZ_FOO__MIN = 42 -> foo.min">>],
                                 lists:sort(binary:split(iolist_to_binary(Stdout),
                                                         <<"\n">>, [global, trim])))
                end).

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -221,6 +221,18 @@ env_test_() ->
                     F("", [{"EMQX_FOO__GREET", "hello"}]))
     ].
 
+env_array_val_test() ->
+    Sc = #{structs => [?VIRTUAL_ROOT],
+           fields => [{"val", hoconsc:array(string())}]
+          },
+    Conf = "val = [a,b]",
+    {ok, PlainMap} = hocon:binary(Conf, #{}),
+    ?assertEqual(#{<<"val">> => ["c", "d"]},
+        with_envs(fun hocon_schema:check_plain/2, [Sc, PlainMap],
+            [ {"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"}
+            , {"EMQX_VAL", "[c, d]"}
+            ])).
+
 translate_test_() ->
     F = fun (Str) -> {ok, M} = hocon:binary(Str, #{format => richmap}),
                      {Mapped, Conf} = hocon_schema:map(demo_schema, M),


### PR DESCRIPTION
Just want to set the array values using environment, like this:

```
EMQX_CLUSTER__STATIC__SEEDS="[emqx@node1.emqx.io, emqx@node2.emqx.io]" sh -x _build/emqx/rel/emqx/bin/emqx console
```