### PR TITLE
fix(parser): the hocon parser crashed on reporting the 'parse_error'

### DIFF
--- a/src/hocon_parser.yrl
+++ b/src/hocon_parser.yrl
@@ -75,17 +75,19 @@ make_variable({V, Line, Value}) when V =:= variable orelse V =:= endvar ->
     #{type => variable, value => Value, name => Value, metadata => #{line => Line}, required => true}.
 
 make_include(String, true) ->  #{type => include,
-                                 value => value_of(String),
+                                 value => bin(value_of(String)),
                                  metadata => #{line => line_of(String)},
                                  required => true};
 make_include(String, false) ->  #{type => include,
-                                  value => value_of(String),
+                                  value => bin(value_of(String)),
                                   metadata => #{line => line_of(String)},
                                   required => false}.
 
 make_concat(S) -> #{type => concat, value => S}.
 
-str_to_bin(#{type := T, value := V} = M) when T =:= string -> M#{value => iolist_to_binary(V)}.
+str_to_bin(#{type := T, value := V} = M) when T =:= string -> M#{value => bin(V)}.
 
 line_of(Token) -> element(2, Token).
 value_of(Token) -> element(3, Token).
+
+bin(Value) -> iolist_to_binary(Value).

--- a/src/hocon_scanner.xrl
+++ b/src/hocon_scanner.xrl
@@ -93,11 +93,11 @@ Rules.
 {Unquoted}        : {token, maybe_include(TokenChars, TokenLine)}.
 {Integer}         : {token, {integer, TokenLine, list_to_integer(TokenChars)}}.
 {Float}           : {token, {float, TokenLine, to_float(TokenChars)}}.
-{String}          : {token, {string, TokenLine, iolist_to_binary(unquote(TokenChars))}}.
-{MultilineString} : {token, {string, TokenLine, iolist_to_binary(unquote(TokenChars))}}.
-{Bytesize}        : {token, {string, TokenLine, iolist_to_binary(TokenChars)}}.
-{Percent}         : {token, {string, TokenLine, iolist_to_binary(TokenChars)}}.
-{Duration}        : {token, {string, TokenLine, iolist_to_binary(TokenChars)}}.
+{String}          : {token, {string, TokenLine, unquote(TokenChars)}}.
+{MultilineString} : {token, {string, TokenLine, unquote(TokenChars)}}.
+{Bytesize}        : {token, {string, TokenLine, TokenChars}}.
+{Percent}         : {token, {string, TokenLine, TokenChars}}.
+{Duration}        : {token, {string, TokenLine, TokenChars}}.
 {Variable}        : {token, {variable, TokenLine, var_ref_name(TokenChars)}}.
 {MaybeVar}        : {token, {variable, TokenLine, {maybe, maybe_var_ref_name(TokenChars)}}}.
 {Required}        : {token, {required, TokenLine}, get_filename_from_required(TokenChars)}.
@@ -106,7 +106,7 @@ Rules.
 Erlang code.
 
 maybe_include("include", TokenLine)  -> {include, TokenLine};
-maybe_include(TokenChars, TokenLine) -> {string, TokenLine, iolist_to_binary(TokenChars)}.
+maybe_include(TokenChars, TokenLine) -> {string, TokenLine, TokenChars}.
 
 get_filename_from_required("required(" ++ Filename) ->
     [$) | FilenameRev] = lists:reverse(Filename),

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -604,6 +604,7 @@ collect_envs(Ns) ->
 
 read_hocon_val("") -> "";
 read_hocon_val(Value) ->
+    io:format(standard_error, "read_hocon_val: ~p~n", [Value]),
     case hocon:binary(Value, #{}) of
         {ok, HoconVal} -> HoconVal;
         {error, _} -> read_informal_hocon_val(Value)

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -604,7 +604,6 @@ collect_envs(Ns) ->
 
 read_hocon_val("") -> "";
 read_hocon_val(Value) ->
-    io:format(standard_error, "read_hocon_val: ~p~n", [Value]),
     case hocon:binary(Value, #{}) of
         {ok, HoconVal} -> HoconVal;
         {error, _} -> read_informal_hocon_val(Value)

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -33,10 +33,10 @@ test_file_load("file-include", F) ->
     ?assertMatch({error, {scan_error, _}}, hocon:load(F));
 %% unquoted string starting by null is not allowed.
 test_file_load("test01", F) ->
-    ?assertError(_, hocon:load(F));
+    ?assertMatch({error, {parse_error, _}}, hocon:load(F));
 %% includes test01
 test_file_load("include-from-list", F) ->
-    ?assertError(_, hocon:load(F));
+    ?assertMatch({error, {parse_error, _}}, hocon:load(F));
 %% do not allow quoted variable name.
 test_file_load("test02"++_, F) ->
     ?assertMatch({error, {scan_error, _}}, hocon:load(F));


### PR DESCRIPTION
The parser crashed when reporting the `parse_error`:

```
5> hocon:binary("abc ab", #{}).

(<0.277.0>) call hocon_token:parse([{string,1,<<"abc">>},{endstr,1,<<"ab">>}],#{filename => [undefined],path => ['$root']}) ({hocon_util,pipeline,3})

(<0.277.0>) exception_from {hocon_token,parse,2} {error,function_clause}
** exception error: no function clause matching io_lib:write_string1(unicode_as_unicode,<<"abc">>,34) (io_lib.erl, line 581)

in function  io_lib:write_string/2 (io_lib.erl, line 553)
in call from hocon_parser:yeccerror/1 (/Users/liuxy/kerl/23.2.5/lib/parsetools-2.2/include/yeccpre.hrl, line 135)
in call from hocon_parser:yeccpars0/5 (/Users/liuxy/kerl/23.2.5/lib/parsetools-2.2/include/yeccpre.hrl, line 57)
in call from hocon_token:parse/2 (/Users/liuxy/code/emqx50/_build/default/lib/hocon/src/hocon_token.erl, line 137)
in call from hocon_util:pipeline/3 (/Users/liuxy/code/emqx50/_build/default/lib/hocon/src/hocon_util.erl, line 42)
in call from hocon:binary/2 (/Users/liuxy/code/emqx50/_build/default/lib/hocon/src/hocon.erl, line 92)
```