### PR TITLE
feat(hocon_schema): report source value location in errors

### DIFF
--- a/src/hocon.erl
+++ b/src/hocon.erl
@@ -313,7 +313,7 @@ do_concat([#{?HOCON_T := object}=O | More], Metadata, Acc) ->
 do_concat([#{?HOCON_T := string}=S | More], Metadata, Acc) ->
     do_concat(More, Metadata, [S | Acc]);
 do_concat([#{?HOCON_T := concat}=C | More], Metadata, Acc) ->
-    ConcatC = do_concat(value_of(C), Metadata#{line => line_of(C), filename => filename_of(C)}),
+    ConcatC = do_concat(value_of(C), new_meta(Metadata, filename_of(C), line_of(C))),
     do_concat([ConcatC | More], Metadata, Acc);
 do_concat([{#{?HOCON_T := key}=K, Value} | More], Metadata, Acc) ->
     do_concat(More, Metadata, [{K, verify_concat(Value)} | Acc]);
@@ -418,3 +418,8 @@ name_of(#{?HOCON_T := variable, name := N}) ->
 
 duration(X) ->
     hocon_postprocess:duration(X).
+
+new_meta(Meta, Filename, Line) ->
+    L = [{filename, Filename}, {line, Line}],
+    NewMeta = maps:from_list([{N, V} || {N, V} <- L, V =/= undefined]),
+    maps:merge(Meta, NewMeta).

--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -286,10 +286,14 @@ stringify_line(K, V) when is_list(V) ->
 stringify_line(K, V) ->
     io_lib:format("~s ~w", [K, V]).
 
+log_for_generator(_Level, #{hocon_env_var_name := Var, path := P, value := V}) when is_binary(V) ->
+    ?STDOUT("~s = ~s = ~s", [P, Var, V]);
 log_for_generator(_Level, #{hocon_env_var_name := Var, path := P, value := V}) ->
-    ?STDOUT("~s = ~0p -> ~s", [Var, V, P]);
+    ?STDOUT("~s = ~s = ~0p", [P, Var, V]);
 log_for_generator(debug, _Args) -> ok;
 log_for_generator(info, _Args) -> ok;
+log_for_generator(Level, Msg) when is_binary(Msg) ->
+    io:format(standard_error, "[~0p] ~s~n", [Level, Msg]);
 log_for_generator(Level, Args) ->
     io:format(standard_error, "[~0p] ~0p~n", [Level, Args]).
 

--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -25,7 +25,6 @@
 
 -define(STDERR(Str, Args), io:format(standard_error, Str ++ "~n", Args)).
 -define(STDOUT(Str, Args), io:format(Str ++ "~n", Args)).
--define(FORMAT(Str, Args), io_lib:format(Str, Args)).
 -define(FORMAT_TEMPLATE, [time, " [", level, "] ", msg, "\n"]).
 
 -type file_error() :: file:posix()  %% copied from file:format_error/1
@@ -112,7 +111,7 @@ main(Args) ->
 %% equav command: date -u +"%Y.%m.%d.%H.%M.%S"
 now_time() ->
     {{Y, M, D}, {HH, MM, SS}} = calendar:local_time(),
-    ?STDOUT("~p.~2..0b.~2..0b.~2..0b.~2..0b.~2..0b", [Y, M, D, HH, MM, SS]).
+    ?STDOUT("~0p.~2..0b.~2..0b.~2..0b.~2..0b.~2..0b", [Y, M, D, HH, MM, SS]).
 
 is_valid_now_time(T) ->
     re:run(T, "^[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]{2}\.[0-9]{2}\.[0-9]{2}$") =/= nomatch.
@@ -132,7 +131,7 @@ get(ParsedArgs, [Query | _]) ->
     %% do not log anything for `get` commands
     DummyLogger = #{logger => fun(_, _) -> ok end},
     {_, NewConf} = hocon_schema:map(Schema, Conf, [RootName], DummyLogger),
-    ?STDOUT("~p", [hocon_schema:get_value(Query, NewConf)]),
+    ?STDOUT("~0p", [hocon_schema:get_value(Query, NewConf)]),
     stop_ok().
 
 load_schema(ParsedArgs) ->
@@ -149,10 +148,10 @@ load_schema(ParsedArgs) ->
 -spec load_conf([proplists:property()], function()) -> hocon:config() | no_return().
 load_conf(ParsedArgs, LogFunc) ->
     ConfFiles = proplists:get_all_values(conf_file, ParsedArgs),
-    LogFunc(debug, "ConfFiles: ~p", [ConfFiles]),
+    LogFunc(debug, "ConfFiles: ~0p", [ConfFiles]),
     case hocon:files(ConfFiles, #{format => richmap}) of
         {error, E} ->
-            LogFunc(error, "~p~n", [E]),
+            LogFunc(error, "~0p~n", [E]),
             stop_deactivate();
         {ok, Conf} ->
             Conf
@@ -200,7 +199,7 @@ generate(ParsedArgs) ->
 
     DestinationVMArgsFilename = filename_maker("vm", NowTime, "args"),
     DestinationVMArgs = filename:join(AbsPath, DestinationVMArgsFilename),
-    log(debug, "Generating config in: ~p", [Destination]),
+    log(debug, "Generating config in: ~0p", [Destination]),
 
     Schema = load_schema(ParsedArgs),
     Conf = load_conf(ParsedArgs, fun log/3),
@@ -229,8 +228,8 @@ generate(ParsedArgs) ->
             end
     catch
         throw : {Schema, Errors} ->
-            log(error, "failed_to_check_schema: ~p", [Schema]),
-            lists:foreach(fun(E) -> log(error, "~p", [E]) end, Errors),
+            log(error, "failed_to_check_schema: ~0p", [Schema]),
+            lists:foreach(fun(E) -> log(error, "~0p", [E]) end, Errors),
             stop_deactivate()
     end.
 
@@ -260,7 +259,7 @@ do_delete([File | Files], Left) ->
     case file:delete(File) of
         ok -> ok;
         {error, Reason} ->
-            log(error, "Could not delete ~s, ~p", [File, Reason])
+            log(error, "Could not delete ~s, ~0p", [File, Reason])
     end,
     do_delete(Files, Left - 1).
 
@@ -288,11 +287,11 @@ stringify_line(K, V) ->
     io_lib:format("~s ~w", [K, V]).
 
 log_for_generator(_Level, #{hocon_env_var_name := Var, path := P, value := V}) ->
-    ?STDOUT("~s = ~p -> ~s", [Var, V, P]);
+    ?STDOUT("~s = ~0p -> ~s", [Var, V, P]);
 log_for_generator(debug, _Args) -> ok;
 log_for_generator(info, _Args) -> ok;
 log_for_generator(Level, Args) ->
-    io:format(standard_error, "[~p] ~p~n", [Level, Args]).
+    io:format(standard_error, "[~0p] ~0p~n", [Level, Args]).
 
 -ifndef(TEST).
 stop_deactivate() ->
@@ -321,8 +320,8 @@ log(Level, Fmt, Args) ->
 %% log to stderr for 'get' command
 log_for_get(L, Fmt, Args) when L =:= debug orelse L =:= info ->
     case os:getenv("DEBUG") of
-        "1" -> ?STDERR("[~p]: " ++ Fmt, [L | Args]);
+        "1" -> ?STDERR("[~0p]: " ++ Fmt, [L | Args]);
         _ -> ok
     end;
 log_for_get(L, Fmt, Args) ->
-    ?STDERR("[~p]: " ++ Fmt, [L | Args]).
+    ?STDERR("[~0p]: " ++ Fmt, [L | Args]).

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -521,7 +521,7 @@ is_known_field(Opts, Name, Value, ExpectedNames) ->
     is_known_name(Name, ExpectedNames) orelse
     case Value of
         #{?HOCON_V := ?FROM_ENV_VAR(EnvName, _)} ->
-            log(Opts, warning, "unknown_environment_variable_discarded: " ++ EnvName),
+            log(Opts, warning, bin(["unknown_environment_variable_discarded: ", EnvName])),
             true;
         _ ->
             false
@@ -676,9 +676,10 @@ obfuscate(Schema, Value) ->
         _ -> Value
     end.
 
-
 log(#{logger := Logger}, Level, Msg) ->
     Logger(Level, Msg);
+log(_Opts, Level, Msg) when is_binary(Msg) ->
+    logger:log(Level, "~s", [Msg]);
 log(_Opts, Level, Msg) ->
     logger:log(Level, Msg).
 

--- a/src/hocon_token.erl
+++ b/src/hocon_token.erl
@@ -142,10 +142,10 @@ parse(Tokens, Ctx) ->
     end.
 
 -spec include(boxed(), hocon:ctx()) -> boxed().
-include(#{?HOCON_T := object}=O, Ctx) ->
+include(#{?HOCON_T := object} = O, Ctx) ->
     NewV = do_include(value_of(O), [], Ctx, hocon_util:get_stack(path, Ctx)),
-    NewMeta = #{filename => hd(hocon_util:get_stack(filename, Ctx))},
-    hocon_util:deep_merge(O, #{?HOCON_V => NewV, ?METADATA => NewMeta}).
+    Filename = hd(hocon_util:get_stack(filename, Ctx)),
+    hocon_util:deep_merge(O, box_v(Filename, NewV)).
 
 do_include([], Acc, _Ctx, _CurrentPath) ->
     lists:reverse(Acc);
@@ -159,28 +159,41 @@ do_include([#{?HOCON_T := include}=Include | More], Acc, Ctx, CurrentPath) ->
     end;
 do_include([#{?HOCON_T := variable}=V | More], Acc, Ctx, CurrentPath) ->
     VarWithAbsPath = abspath(value_of(V), hocon_util:get_stack(path, Ctx)),
-    NewV = hocon_util:deep_merge(V, #{?METADATA => #{filename => filename(Ctx)},
-                                         ?HOCON_V => VarWithAbsPath}),
+    NewV = hocon_util:deep_merge(V, box_v(filename(Ctx), VarWithAbsPath)),
     do_include(More, [NewV | Acc], Ctx, CurrentPath);
 do_include([{Key, #{?HOCON_T := T}=X} | More], Acc, Ctx, CurrentPath) when ?IS_VALUE_LIST(T) ->
-    NewKey = hocon_util:deep_merge(Key, #{?METADATA => #{filename => filename(Ctx)}}),
+    NewKey = hocon_util:deep_merge(Key, box(filename(Ctx))),
     NewValue = do_include(value_of(X), [], Ctx, [Key | CurrentPath]),
-    NewMeta = #{filename => filename(Ctx), line => line_of(Key)},
-    NewX = hocon_util:deep_merge(X, #{?METADATA => NewMeta, ?HOCON_V => NewValue}),
+    NewX = hocon_util:deep_merge(X, box_v(filename(Ctx), line_of(Key), NewValue)),
     do_include(More, [{NewKey, NewX} | Acc], Ctx, CurrentPath);
 do_include([#{?HOCON_T := T}=X | More], Acc, Ctx, CurrentPath) when ?IS_VALUE_LIST(T) ->
     NewValue = do_include(value_of(X), [], Ctx, CurrentPath),
-    do_include(More, [hocon_util:deep_merge(X, #{?METADATA => #{filename => filename(Ctx)},
-                                                    ?HOCON_V => NewValue}) | Acc],
+    do_include(More, [hocon_util:deep_merge(X, box_v(filename(Ctx), NewValue)) | Acc],
                Ctx, CurrentPath);
 do_include([{Key, #{?HOCON_T := _T}=X} | More], Acc, Ctx, CurrentPath) ->
-    NewKey = hocon_util:deep_merge(Key, #{?METADATA => #{filename => filename(Ctx)}}),
-    NewX = hocon_util:deep_merge(X, #{?METADATA => #{filename => filename(Ctx),
-                                                        line => line_of(Key)}}),
+    NewKey = hocon_util:deep_merge(Key, box(filename(Ctx))),
+    NewX = hocon_util:deep_merge(X, box(filename(Ctx), line_of(Key))),
     do_include(More, [{NewKey, NewX} | Acc], Ctx, CurrentPath);
 do_include([#{?HOCON_T := _T}=X | More], Acc, Ctx, CurrentPath) ->
-    NewX = hocon_util:deep_merge(X, #{?METADATA => #{filename => filename(Ctx)}}),
+    NewX = hocon_util:deep_merge(X, box(filename(Ctx))),
     do_include(More, [NewX | Acc], Ctx, CurrentPath).
+
+box_v(Filename, Value) ->
+    box_v(Filename, _Line = undefined, Value).
+
+box_v(Filename, Line, Value) ->
+    Box = box(Filename, Line),
+    Box#{?HOCON_V => Value}.
+
+box(Filename) ->
+    mk_box([{filename, Filename}]).
+
+box(Filename, Line) ->
+    mk_box([{filename, Filename}, {line, Line}]).
+
+mk_box(MetaFields) ->
+    Meta = maps:from_list(lists:filter(fun({_, V}) -> V =/= undefined end, MetaFields)),
+    #{?METADATA => Meta}.
 
 filename(Ctx) ->
     hocon_util:top_stack(filename, Ctx).

--- a/test/hocon_cli_tests.erl
+++ b/test/hocon_cli_tests.erl
@@ -115,8 +115,8 @@ generate_with_env_logging_test() ->
                              [{"ZZZ_FOO__MIN", "42"}, {"ZZZ_FOO__MAX", "43"},
                               {"HOCON_ENV_OVERRIDE_PREFIX", "ZZZ_"}]),
                    {ok, Stdout} = cuttlefish_test_group_leader:get_output(),
-                   ?assertEqual([<<"ZZZ_FOO__MAX = 43 -> foo.max">>,
-                                 <<"ZZZ_FOO__MIN = 42 -> foo.min">>],
+                   ?assertEqual([<<"foo.max = ZZZ_FOO__MAX = 43">>,
+                                 <<"foo.min = ZZZ_FOO__MIN = 42">>],
                                 lists:sort(binary:split(iolist_to_binary(Stdout),
                                                         <<"\n">>, [global, trim])))
                end).

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -371,7 +371,7 @@ atom_key_array_test() ->
     ?assertEqual(#{arr => [#{id => 1}, #{id => 2}]},
                  hocon_schema:check_plain(Sc, PlainMap, #{atom_key => true})),
     ?assertMatch({_, #{arr := [#{id := 1}, #{id := 2}]}},
-                 hocon_schema:map(Sc, PlainMap, all, #{is_richmap => false, atom_key => true})).
+                 hocon_schema:map(Sc, PlainMap, all, #{format => map, atom_key => true})).
 
 %% if convert to non-existing atom
 atom_key_failure_test() ->
@@ -382,7 +382,7 @@ atom_key_failure_test() ->
     Conf = "non_existing_atom_as_key=1",
     {ok, PlainMap} = hocon:binary(Conf, #{}),
     ?assertError({non_existing_atom, <<"non_existing_atom_as_key">>},
-                 hocon_schema:map(Sc, PlainMap, all, #{is_richmap => false, atom_key => true})).
+                 hocon_schema:map(Sc, PlainMap, all, #{format => map, atom_key => true})).
 
 return_plain_test_() ->
     Sc = #{structs => [?VIRTUAL_ROOT],

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -106,7 +106,7 @@ unknown_env_test() ->
     receive
         {Ref, Level, Msg} ->
             ?assertEqual(warning, Level),
-            ?assertEqual("unknown_environment_variable_discarded: EMQX_BAR__UNKNOWNx", Msg)
+            ?assertEqual(<<"unknown_environment_variable_discarded: EMQX_BAR__UNKNOWNx">>, Msg)
     end.
 
 check(Str) ->

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -484,15 +484,12 @@ validation_error_if_not_nullable_test() ->
     ?VALIDATION_ERR(#{reason := not_nullable},
                     hocon_schema:check_plain(Sc, Data, #{nullable => false})).
 
-unknown_fields_test() ->
+unknown_fields_test_() ->
     Conf = "person.id.num=123,person.name=mike",
     {ok, M} = hocon:binary(Conf, #{format => richmap}),
     ?GEN_VALIDATION_ERR(#{reason := unknown_fields,
-                          unknown := [<<"name">>]},
-                        begin
-                            {Mapped, _} = hocon_schema:map(demo_schema, M, all),
-                            Mapped
-                        end).
+                          unknown := [{<<"name">>, #{filename := undefined, line := 1}}]
+                         }, hocon_schema:map(demo_schema, M, all)).
 
 nullable_field_test() ->
     Sc = #{structs => [?VIRTUAL_ROOT],

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -512,7 +512,7 @@ unknown_fields_test_() ->
     Conf = "person.id.num=123,person.name=mike",
     {ok, M} = hocon:binary(Conf, #{format => richmap}),
     ?GEN_VALIDATION_ERR(#{reason := unknown_fields,
-                          unknown := [{<<"name">>, #{filename := undefined, line := 1}}]
+                          unknown := [{<<"name">>, #{line := 1}}]
                          }, hocon_schema:map(demo_schema, M, all)).
 
 nullable_field_test() ->

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -407,41 +407,40 @@ duration_test_() ->
 
 richmap_binary_test() ->
     {ok, M0} = hocon:binary("a=1", #{format => richmap}),
-    ?assertEqual(#{?METADATA => #{filename => undefined, line => 0},
+    ?assertEqual(#{?METADATA => #{line => 0},
                    ?HOCON_T => object,
                    ?HOCON_V =>
                    #{<<"a">> =>
-                     #{?METADATA => #{filename => undefined, line => 1},
+                     #{?METADATA => #{line => 1},
                        ?HOCON_T => integer,
                        ?HOCON_V => 1}}}, M0),
     {ok, M1} = hocon:binary("a=[1,2]", #{format => richmap}),
-    ?assertEqual(#{?METADATA => #{filename => undefined, line => 0},
+    ?assertEqual(#{?METADATA => #{line => 0},
                    ?HOCON_T => object,
                    ?HOCON_V =>
                    #{<<"a">> =>
-                     #{?METADATA => #{filename => undefined, line => 1},
+                     #{?METADATA => #{line => 1},
                        ?HOCON_T => array,
                        ?HOCON_V =>
                        [#{?METADATA =>
-                          #{filename => undefined, line => 1},
+                          #{line => 1},
                           ?HOCON_T => integer,
                           ?HOCON_V => 1},
                         #{?METADATA =>
-                          #{filename => undefined, line => 1},
+                          #{line => 1},
                           ?HOCON_T => integer,
                           ?HOCON_V => 2}]}}}, M1),
     {ok, M2} = hocon:binary("a\n{b=foo}", #{format => richmap}),
-    ?assertEqual(#{?METADATA => #{filename => undefined, line => 0},
+    ?assertEqual(#{?METADATA => #{line => 0},
                    ?HOCON_T => object,
                    ?HOCON_V =>
                    #{<<"a">> =>
-                     #{?METADATA => #{filename => undefined, line => 1},
+                     #{?METADATA => #{line => 1},
                        ?HOCON_T => object,
                        ?HOCON_V =>
                        #{<<"b">> =>
                          #{?METADATA =>
-                           #{filename => undefined,
-                             line => 2},
+                           #{line => 2},
                            ?HOCON_T => string,
                            ?HOCON_V => <<"foo">>}}}}}, M2).
 


### PR DESCRIPTION
for unknown data fields and field values failed at validation,
now the `map`, `check` and `check_plain` APIs report data origin metadata
such as file name (if loaded from hocon file), os environment name, etc.