### PR TITLE
feat(schema): add option 'no_conversion' to hocon_schema:check_plain/3

### DIFF
--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -88,6 +88,7 @@
 -define(IS_NON_EMPTY_STRING(X), (is_list(X) andalso X =/= [] andalso is_integer(hd(X)))).
 -type loggerfunc() :: fun((atom(), map()) -> ok).
 -type opts() :: #{ logger => loggerfunc()
+                 , no_conversion => boolean()
                  , atom_key => boolean()
                  , return_plain => boolean()
                    %% By default allow all fields to be undefined.
@@ -476,7 +477,10 @@ map_field(Type, Schema, Value0, Opts) ->
         ConvertedValue ->
             Validators = add_default_validator(field_schema(Schema, validator), Type),
             ValidationResult = validate(Opts, Schema, ConvertedValue, Validators),
-            {ValidationResult, boxit(Opts, ConvertedValue, Value0)}
+            case Opts of
+                #{no_conversion := true} -> {ValidationResult, Value0};
+                _ -> {ValidationResult, boxit(Opts, ConvertedValue, Value0)}
+            end
     catch
         C : E : St ->
             {validation_errs(Opts, #{reason => converter_crashed,

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -711,3 +711,18 @@ default_value_for_null_enclosing_struct_test() ->
                  hocon_schema:check_plain(Sc, PlainMap, #{nullable => true})),
     ?assertEqual(#{<<"l1">> => #{<<"l2">> => 22}},
                  hocon_schema:check(Sc, RichMap, #{nullable => true, return_plain => true})).
+
+fill_defaults_test() ->
+    Sc = #{structs => ["a"],
+           fields => #{"a" =>
+               [ {b, hoconsc:t(integer(), #{default => 888})}
+               , {c, hoconsc:t(integer(), #{
+                   default => "15s",
+                   converter => fun (Dur) -> hocon_postprocess:duration(Dur) end})}
+               ]}
+          },
+    ?assertMatch(#{<<"a">> := #{<<"b">> := 888, <<"c">> := 15000}},
+        hocon_schema:check_plain(Sc, #{}, #{nullable => true})),
+    ?assertMatch(#{<<"a">> := #{<<"b">> := 888, <<"c">> := "15s"}},
+        hocon_schema:check_plain(Sc, #{}, #{nullable => true, no_conversion => true})),
+    ok.


### PR DESCRIPTION
Use `hocon_schema:check_plain/3` to fill the default values (not converted by convertors) to a map:

```
(emqx@127.0.0.1)2> hocon_schema:check_plain(emqx_schema, #{<<"alarm">> => #{}}, #{nullable => true}).
#{<<"alarm">> =>
      #{<<"actions">> => [log,publish],
        <<"size_limit">> => 1000,<<"validity_period">> => "24h"},
  ...
```