### PR TITLE
fix(hocon_schema): allow non-primitive fields to be nullable

### DIFF
--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -685,7 +685,7 @@ default_value_map_field_test() ->
            fields => #{?VIRTUAL_ROOT => [ {k, #{type => hoconsc:ref(sub),
                                                 default => #{<<"a">> => <<"foo">>,
                                                              <<"b">> => <<"bar">>}}}
-                                          , {x, string()}
+                                        , {x, string()}
                                         ],
                        sub => [{a, string()}, {b, string()}]
                       }
@@ -782,3 +782,17 @@ root_array_env_override_test() ->
             {"EMQX_FOO__1__KLING", "111"},
             {"EMQX_FOO__2__KLANG", "222"}
            ]).
+
+ref_nullable_test() ->
+    Sc = #{structs => [?VIRTUAL_ROOT],
+           fields => #{?VIRTUAL_ROOT => [ {k, #{type => hoconsc:ref(sub),
+                                                nullable => {true, recursively}}}
+                                        , {x, string()}
+                                        ],
+                       sub => [{a, string()}, {b, string()}]
+                      }
+          },
+    Conf = "x = y",
+    {ok, RichMap} = hocon:binary(Conf, #{format => richmap}),
+    ?assertEqual(#{<<"x">> => "y"},
+                 hocon_schema:richmap_to_map(hocon_schema:check(Sc, RichMap))).


### PR DESCRIPTION
prior to this fix, only primitive value fileds (leaf-nodes) are allowed
to declare 'nullable'.
non-primitive values fields such as sub-struct (reference) fields'
'nullable' property had no effect.

this commit made the schema check to take all field's 'nullable'
property into account.
in many cases, a parent level field's 'nullable' property should
mask all children fields (so they do not have to all declare to
be 'nullable' recursively). however to be backward compatible
(to be able to generate configs from default values),
we had to introduce a new property-value `{true, recursively}`