### PR TITLE
feat(hocon_schema): Add a 'lazy' type

### DIFF
--- a/include/hoconsc.hrl
+++ b/include/hoconsc.hrl
@@ -24,4 +24,9 @@
 -define(ENUM(OfSymbols), {enum, OfSymbols}).
 -define(IS_TYPEREFL(X), (is_tuple(X) andalso element(1, Type) =:= '$type_refl')).
 
+%% a field having lazy reference type is not type-checked as a part of its enclosing struct
+%% the user of this field is responsible for type checks at runtime
+%% the hint type is useful when generating documents
+-define(LAZY(HintType), {'$lazy', HintType}).
+
 -endif.

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -527,6 +527,8 @@ map_field(?ARRAY(Type), _FieldSchema, Value0, Opts) ->
         false ->
             {validation_errs(Opts, not_array, Value0), Value0}
     end;
+map_field(?LAZY(_HintType), _Schema, Value, _Opts) ->
+    {[], Value};
 map_field(Type, Schema, Value0, Opts) ->
     %% primitive type
     Value = unbox(Opts, Value0),

--- a/src/hoconsc.erl
+++ b/src/hoconsc.erl
@@ -20,6 +20,7 @@
 -export([t/1, t/2]).
 -export([ref/1, ref/2]).
 -export([array/1, union/1, enum/1]).
+-export([lazy/1]).
 
 -include("hoconsc.hrl").
 
@@ -43,3 +44,5 @@ union(OfTypes) when is_list(OfTypes) -> ?UNION(OfTypes).
 
 %% @doc make a enum type.
 enum(OfSymbols) when is_list(OfSymbols) -> ?ENUM(OfSymbols).
+
+lazy(HintType) -> ?LAZY(HintType).

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -796,3 +796,15 @@ ref_nullable_test() ->
     {ok, RichMap} = hocon:binary(Conf, #{format => richmap}),
     ?assertEqual(#{<<"x">> => "y"},
                  hocon_schema:richmap_to_map(hocon_schema:check(Sc, RichMap))).
+
+lazy_test() ->
+    Sc = #{structs => [?VIRTUAL_ROOT],
+           fields => #{?VIRTUAL_ROOT => [ {k, #{type => hoconsc:lazy(integer())}}
+                                        , {x, string()}
+                                        ]
+                      }
+          },
+    Conf = "x = y, k=whatever",
+    {ok, RichMap} = hocon:binary(Conf, #{format => richmap}),
+    ?assertEqual(#{<<"x">> => "y", <<"k">> => <<"whatever">>},
+                 hocon_schema:richmap_to_map(hocon_schema:check(Sc, RichMap))).


### PR DESCRIPTION
In order to support plugable configuration, sometimes we need to
delay the schema check of config at plugable app's runtime