### PR TITLE
feat: add doc namespace

### DIFF
--- a/sample-schemas/demo_schema2.erl
+++ b/sample-schemas/demo_schema2.erl
@@ -4,7 +4,9 @@
 
 -behaviour(hocon_schema).
 
--export([roots/0, fields/1]).
+-export([namespace/0, roots/0, fields/1]).
+
+namespace() -> undefined.
 
 roots() ->
     [ {foo, hoconsc:array(hoconsc:ref(foo))}

--- a/src/hocon_md.erl
+++ b/src/hocon_md.erl
@@ -66,4 +66,5 @@ anchor(Anchor0) ->
                 end, Anchor, Replaces).
 
 bin(S) when is_list(S) -> unicode:characters_to_binary(S, utf8);
-bin(A) when is_atom(A) -> atom_to_binary(A, utf8).
+bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
+bin(B) when is_binary(B) -> B.

--- a/src/hocon_schema_doc.erl
+++ b/src/hocon_schema_doc.erl
@@ -102,7 +102,14 @@ do_type(Ns, ?LAZY(T)) -> do_type(Ns, T);
 do_type(_Ns, {'$type_refl', #{name := Type}}) -> hocon_md:code(lists:flatten(Type)).
 
 ref(undefined, Name) -> Name;
-ref(Ns, Name) -> [bin(Ns), ":", bin(Name)].
+ref(Ns, Name) ->
+    %% when namespace is the same as reference name
+    %% we do not prepend the reference link with namespace
+    %% because the root name is already unique enough
+    case bin(Ns) =:= bin(Name) of
+        true -> bin(Ns);
+        false -> [bin(Ns), ":", bin(Name)]
+    end.
 
 bin(S) when is_list(S) -> iolist_to_binary(S);
 bin(A) when is_atom(A) -> atom_to_binary(A, utf8);

--- a/src/hocon_schema_doc.erl
+++ b/src/hocon_schema_doc.erl
@@ -102,7 +102,7 @@ do_type(Ns, ?LAZY(T)) -> do_type(Ns, T);
 do_type(_Ns, {'$type_refl', #{name := Type}}) -> hocon_md:code(lists:flatten(Type)).
 
 ref(undefined, Name) -> Name;
-ref(Ns, Name) -> [bin(Ns), ".", bin(Name)].
+ref(Ns, Name) -> [bin(Ns), ":", bin(Name)].
 
 bin(S) when is_list(S) -> iolist_to_binary(S);
 bin(A) when is_atom(A) -> atom_to_binary(A, utf8);

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -765,10 +765,11 @@ lazy_root_test() ->
 
 lazy_root_env_override_test() ->
     Sc = #{roots => [{foo, hoconsc:lazy(hoconsc:ref(bar))}],
-           fields => #{bar => [ {"kling", hoconsc:mk(integer())},
-                                {"klang", hoconsc:mk(integer())}
-                              ]
-                      }
+           fields => fun(bar) ->
+                             [ {"kling", hoconsc:mk(integer())}
+                             , {"klang", hoconsc:mk(integer())}
+                             ]
+                     end
           },
     with_envs(
       fun() ->
@@ -784,3 +785,8 @@ lazy_root_env_override_test() ->
             {"EMQX_FOO__KLING", "111"},
             {"EMQX_FOO__KLANG", "222"}
            ]).
+
+duplicated_root_names_test() ->
+    Sc = #{roots => [foo, bar, foo]},
+    ?assertError({duplicated_root_names, [<<"foo">>]},
+                 hocon_schema:roots(Sc)).


### PR DESCRIPTION
Added a `namespace/0` behaviour callback so the generated doc headlines can have more readable prefix.
Also changed from `.` to `:` for namespace & name delimiter to follow EMQX's convention.