### PR TITLE
refactor: map type for wildcard fields

### DIFF
--- a/include/hoconsc.hrl
+++ b/include/hoconsc.hrl
@@ -26,9 +26,12 @@
 -define(R_REF(Module, Name), {ref, Module, Name}). % remote ref
 -define(IS_TYPEREFL(X), (is_tuple(X) andalso element(1, Type) =:= '$type_refl')).
 
-%% a field having lazy reference type is not type-checked as a part of its enclosing struct
+%% A field having lazy type is not type-checked as a part of its enclosing struct
 %% the user of this field is responsible for type checks at runtime
 %% the hint type is useful when generating documents
 -define(LAZY(HintType), {lazy, HintType}).
+
+%% Map keys are always strings, `Name' is only for documentation
+-define(MAP(Name, Type), {map, Name, Type}).
 
 -endif.

--- a/sample-schemas/emqx_auth_http_schema.erl
+++ b/sample-schemas/emqx_auth_http_schema.erl
@@ -23,12 +23,9 @@ fields("http") ->
 fields("req") ->
     [ {"url", emqx_schema:t(string(), undefined, undefined)}
     , {"method", emqx_schema:t(union(get, post), undefined, post)}
-    , {"headers", emqx_schema:ref("headers")}
+    , {"headers", hoconsc:map("name", string())}
     , {"params", emqx_schema:t(string(), undefined, undefined)}
     ];
-
-fields("headers") ->
-    [ {"$field", emqx_schema:t(string(), undefined, undefined)}];
 
 % @TODO modify emqx_auth_http_app.erl
 fields("ssl") ->

--- a/sample-schemas/emqx_auth_jwt_schema.erl
+++ b/sample-schemas/emqx_auth_jwt_schema.erl
@@ -26,10 +26,8 @@ fields("jwks") ->
 
 fields("verify_claims") ->
     [ {"enable", emqx_schema:t(emqx_schema:flag(), undefined, false)}
-    , {"claims", emqx_schema:ref("claims")}];
-
-fields("claims") ->
-    [ {"$name", emqx_schema:t(string(), undefined, undefined)}].
+    , {"claims", hoconsc:map("name", string())}
+    ].
 
 translations() -> ["emqx_auth_jwt"].
 

--- a/sample-schemas/emqx_auth_ldap_schema.erl
+++ b/sample-schemas/emqx_auth_ldap_schema.erl
@@ -22,7 +22,7 @@ fields("ldap") ->
     , {"device_dn", t(string(), "emqx_auth_ldap.device_dn", "ou=device,dc=emqx,dc=io")}
     , {"match_objectclass", t(string(), "emqx_auth_ldap.match_objectclass", "mqttUser")}
     , {"custom_base_dn", t(string(), "emqx_auth_ldap.custom_base_dn", "${username_attr}=${user},${device_dn}")}
-    , {"filters", emqx_schema:ref("filters")}
+    , {"filters", hoconsc:map("num", hoconsc:ref("filter"))}
     , {"bind_as_user", t(boolean(), "emqx_auth_ldap.bind_as_user", false)}
     , {"username_attr", t(string(), "emqx_auth_ldap.username_attr", "uid")}
     , {"password_attr", t(string(), "emqx_auth_ldap.password_attr", "userPassword")}
@@ -31,10 +31,7 @@ fields("ldap") ->
 fields("ssl") ->
     emqx_schema:ssl(undefined, #{enable => false, verify => verify_none});
 
-fields("filters") ->
-    [ {"$num", emqx_schema:ref("filter_settings")}];
-
-fields("filter_settings") ->
+fields("filter") ->
     [ {"key", t(string())}
     , {"value", t(string())}
     , {"op", t(union('and', 'or'))}

--- a/sample-schemas/emqx_auth_mnesia_schema.erl
+++ b/sample-schemas/emqx_auth_mnesia_schema.erl
@@ -10,24 +10,19 @@ roots() -> ["auth"].
 
 fields("auth") ->
     [ {"mnesia", emqx_schema:ref("mnesia")}
-    , {"client", emqx_schema:ref("client")}
-    , {"user", emqx_schema:ref("user")}];
+    , {"client", hoconsc:map("id", hoconsc:ref("client"))}
+    , {"user", hoconsc:map("id", hoconsc:ref("user"))}
+    ];
 
 fields("mnesia") ->
     [ {"password_hash", emqx_schema:t(union([plain, md5, sha, sha256, sha512]),
                                       "emqx_auth_mnesia.password_hash", sha256)}];
 
 fields("client") ->
-    [ {"$id", emqx_schema:ref("client_settings")}];
-
-fields("user") ->
-    [ {"$id", emqx_schema:ref("user_settings")}];
-
-fields("client_settings") ->
    [ {"clientid", emqx_schema:t(string())}
    , {"password", emqx_schema:t(string())}];
 
-fields("user_settings") ->
+fields("user") ->
     [ {"username", emqx_schema:t(string())}
     , {"password", emqx_schema:t(string())}].
 

--- a/sample-schemas/emqx_auth_mongo_schema.erl
+++ b/sample-schemas/emqx_auth_mongo_schema.erl
@@ -31,15 +31,12 @@ fields("mongo") ->
     , {"ssl", emqx_schema:ref("ssl")}
     , {"w_mode", fun w_mode/1}
     , {"r_mode", fun r_mode/1}
-    , {"topology", emqx_schema:ref("topology")}
+    , {"topology", hoconsc:map("name", integer())}
     , {"query_timeout", emqx_schema:t(string(), undefined, undefined)}
     , {"auth_query", emqx_schema:ref("auth_query")}
     , {"super_query", emqx_schema:ref("super_query")}
     , {"acl_query", emqx_schema:ref("acl_query")}
     ];
-
-fields("topology") ->
-    [ {"$name", emqx_schema:t(integer(), undefined, undefined)}];
 
 fields("ssl") ->
     [ {"enable", emqx_schema:t(emqx_schema:flag(), undefined, false)}
@@ -63,11 +60,8 @@ fields("acl_query") ->
     [ {"enable", emqx_schema:t(emqx_schema:flag(), undefined, false)}
     , {"collection", emqx_schema:t(string(), undefined, "mqtt_user")}
     , {"selector", emqx_schema:t(string(), undefined, "")}
-    , {"selectors", emqx_schema:ref("selectors")}
-    ];
-
-fields("selectors") ->
-    [ {"$id", emqx_schema:t(string(), undefined, undefined)}].
+    , {"selectors", hoconsc:map("id", string())}
+    ].
 
 translations() -> ["emqx_auth_mongo", "mongodb"].
 

--- a/sample-schemas/emqx_schema.erl
+++ b/sample-schemas/emqx_schema.erl
@@ -52,7 +52,7 @@ fields("cluster") ->
     , {"static", ref("static")}
     , {"mcast", ref("mcast")}
     , {"proto_dist", t(union([inet_tcp, inet6_tcp, inet_tls]), "ekka.proto_dist", inet_tcp)}
-    , {"dns", ref("dns")}
+    , {"dns", "dns"}
     , {"etcd", ref("etcd")}
     , {"k8s", ref("k8s")}
     ];

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -64,7 +64,9 @@
                       | ?UNION([type()])
                       | ?ARRAY(type())
                       | ?ENUM(type())
-                      | field_schema_map().
+                      | field_schema_map()
+                      | field_schema_fun().
+-type field_schema_fun() :: fun((_) -> _).
 -type field_schema_map() ::
         #{ type := type()
          , default => term()
@@ -112,7 +114,6 @@
                  , check_lazy => boolean()
                  }.
 
-
 -callback namespace() -> name().
 -callback roots() -> [root_type()].
 -callback fields(name()) -> [field()].
@@ -141,7 +142,7 @@
 -define(MAGIC_SCHEMA, #{type => ?MAGIC}).
 
 %% @doc Make a higher order schema by overriding `Base' with `OnTop'
--spec override(field_schema(), field_schema_map()) -> field_schema().
+-spec override(field_schema(), field_schema_map()) -> field_schema_fun().
 override(Base, OnTop) ->
     fun(SchemaKey) ->
             case maps:is_key(SchemaKey, OnTop) of

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -32,7 +32,7 @@
 -export([check/2, check/3, check_plain/2, check_plain/3, check_plain/4]).
 -export([richmap_to_map/1, get_value/2, get_value/3]).
 -export([namespace/1, resolve_struct_name/2, root_names/1]).
--export([field_schema/2]).
+-export([field_schema/2, override/2]).
 
 -include("hoconsc.hrl").
 -include("hocon_private.hrl").
@@ -64,19 +64,21 @@
                       | ?UNION([type()])
                       | ?ARRAY(type())
                       | ?ENUM(type())
-                      | #{ type := type()
-                         , default => term()
-                         , mapping => string()
-                         , converter => function()
-                         , validator => function()
-                         , override_env => string()
-                           %% set true if a field is allowed to be `undefined`
-                           %% NOTE: has no point setting it to `true` if field has a default value
-                         , nullable => true | false | {true, recursively} % default = true
-                           %% for sensitive data obfuscation (password, token)
-                         , sensitive => boolean()
-                         , desc => iodata()
-                         }.
+                      | field_schema_map().
+-type field_schema_map() ::
+        #{ type := type()
+         , default => term()
+         , mapping => string()
+         , converter => function()
+         , validator => function()
+         , override_env => string()
+           %% set true if a field is allowed to be `undefined`
+           %% NOTE: has no point setting it to `true` if field has a default value
+         , nullable => true | false | {true, recursively} % default = true
+           %% for sensitive data obfuscation (password, token)
+         , sensitive => boolean()
+         , desc => iodata()
+         }.
 
 -type field() :: {name(), typefunc() | field_schema()}.
 -type translation() :: {name(), translationfunc()}.
@@ -135,6 +137,18 @@
 
 -define(META_BOX(Tag, Metadata), #{?METADATA => #{Tag => Metadata}}).
 -define(NULL_BOX, #{?METADATA => #{made_for => null_value}}).
+-define(MAGIC, '$magic_chicken').
+-define(MAGIC_SCHEMA, #{type => ?MAGIC}).
+
+%% @doc Make a higher order schema by overriding `Base' with `OnTop'
+-spec override(field_schema(), field_schema_map()) -> field_schema().
+override(Base, OnTop) ->
+    fun(SchemaKey) ->
+            case maps:is_key(SchemaKey, OnTop) of
+                true -> field_schema(OnTop, SchemaKey);
+                false -> field_schema(Base, SchemaKey)
+            end
+    end.
 
 %% behaviour APIs
 -spec roots(schema()) -> #{name() => {name(), field_schema()}}.
@@ -374,7 +388,7 @@ map(Schema, Conf0, Roots0, Opts0) ->
     Conf1 = filter_by_roots(Opts, Conf0, Roots),
     {EnvNamespace, Envs} = collect_envs(Opts0),
     Conf = apply_envs(EnvNamespace, Envs, Opts, Roots, Conf1),
-    {Mapped, NewConf} = do_map(Roots, Conf, Opts, root),
+    {Mapped, NewConf} = do_map(Roots, Conf, Opts, ?MAGIC_SCHEMA),
     ok = assert_no_error(Schema, Mapped),
     ok = assert_integrity(Schema, NewConf, Opts),
     {Mapped, maybe_convert_to_plain_map(NewConf, Opts)}.
@@ -430,53 +444,30 @@ str(S) when is_list(S) -> S.
 bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
 bin(S) -> iolist_to_binary(S).
 
-do_map(Fields, Value, Opts, FieldSchema) ->
+do_map(Fields, Value, Opts, ParentSchema) ->
     case unbox(Opts, Value) of
         undefined ->
-            case is_nullable(Opts, FieldSchema) of
+            case is_nullable(Opts, ParentSchema) of
                 {true, recursively} ->
                     {[], boxit(Opts, undefined, undefined)};
                 true ->
                     do_map2(Fields, boxit(Opts, undefined, undefined), Opts,
-                            FieldSchema);
+                            ParentSchema);
                 false ->
                     {validation_errs(Opts, not_nullable, undefined), undefined}
             end;
         V when is_map(V) ->
-            do_map2(Fields, Value, Opts, FieldSchema);
+            do_map2(Fields, Value, Opts, ParentSchema);
         _ ->
             {validation_errs(Opts, bad_value_for_struct, Value), Value}
     end.
 
-%% Conf must be a map from here on
-do_map2([{[$$ | _] = _Wildcard, Schema}], Conf, Opts, FieldSchema) ->
-    %% wildcard: support dynamic field names.
-    %% e.g. in this config:
-    %%     #{config => #{internal => #{val => 1},
-    %%                   external => #{val => 2}}
-    %% `internal` and `external` share the same schema, which is_map
-    %%     [{"val", #{type => integer()}}]
-    %%
-    %% If there is no wildcard, the enclosing schema should be:
-    %%     [{"internal", #{type => "val"}}
-    %%      {"external", #{type => "val"}}]
-    %%
-    %% This will not allow us to add more fields without changing
-    %% the schema (source code). So, wildcard is to the rescue:
-    %% The enclosing field name can be defined with a leading $
-    %% e.g.
-    %%     [{"$name", #{type => "val"}}].
-    Keys = maps_keys(unbox(Opts, Conf)),
-    FieldNames = [str(K) || K <- Keys],
-    % All objects in this map should share the same schema.
-    Fields = [{FieldName, Schema} || FieldName <- FieldNames],
-    do_map(Fields, Conf, Opts, FieldSchema); %% start over
-do_map2(Fields, Value, Opts, _FieldSchema) ->
+do_map2(Fields, Value, Opts, _ParentSchema) ->
     SchemaFieldNames = [N || {N, _Schema} <- Fields],
     DataFields = unbox(Opts, Value),
     case check_unknown_fields(Opts, SchemaFieldNames, DataFields) of
-        ok -> map_fields(Fields, Value, [], Opts);
-        Errors -> {Errors, Value}
+      ok -> map_fields(Fields, Value, [], Opts);
+      Errors -> {Errors, Value}
     end.
 
 map_fields([], Conf, Mapped, _Opts) ->
@@ -501,10 +492,18 @@ map_one_field(FieldType, FieldSchema, FieldValue, Opts) ->
             {Acc, FieldValue}
     end.
 
-map_field({ref, Module, Ref}, FieldSchema, Value, Opts) ->
+map_field(?MAP(_Name, Type), FieldSchema, Value, Opts) ->
+    %% map type always has string keys
+    Keys = maps_keys(unbox(Opts, Value)),
+    FieldNames = [str(K) || K <- Keys],
+    % All objects in this map should share the same schema.
+    NewSc = override(FieldSchema, #{type => Type}),
+    NewFields = [{FieldName, NewSc} || FieldName <- FieldNames],
+    do_map(NewFields, Value, Opts, NewSc); %% start over
+map_field(?R_REF(Module, Ref), FieldSchema, Value, Opts) ->
     %% Switching to another module, good luck.
     do_map(Module:fields(Ref), Value, Opts#{schema := Module}, FieldSchema);
-map_field({ref, Ref}, FieldSchema, Value, #{schema := Schema} = Opts) ->
+map_field(?REF(Ref), FieldSchema, Value, #{schema := Schema} = Opts) ->
     Fields = fields(Schema, Ref),
     do_map(Fields, Value, Opts, FieldSchema);
 map_field(Ref, FieldSchema, Value, #{schema := Schema} = Opts) when is_list(Ref) ->
@@ -630,8 +629,12 @@ is_nullable(Opts, Schema) ->
 field_schema(Atom, type) when is_atom(Atom) -> Atom;
 field_schema(Type, SchemaKey) when ?IS_TYPEREFL(Type) ->
     field_schema(hoconsc:mk(Type), SchemaKey);
+field_schema(?MAP(_Name, _Type) = Map, SchemaKey) ->
+    field_schema(hoconsc:mk(Map), SchemaKey);
 field_schema(?LAZY(_) = Lazy, SchemaKey) ->
     field_schema(hoconsc:mk(Lazy), SchemaKey);
+field_schema(Ref, SchemaKey) when is_list(Ref) ->
+    field_schema(hoconsc:mk(Ref), SchemaKey);
 field_schema(?REF(_) = Ref, SchemaKey) ->
     field_schema(hoconsc:mk(Ref), SchemaKey);
 field_schema(?R_REF(_, _) = Ref, SchemaKey) ->
@@ -644,7 +647,7 @@ field_schema(?ENUM(_) = Enum, SchemaKey) ->
     field_schema(hoconsc:mk(Enum), SchemaKey);
 field_schema(FieldSchema, SchemaKey) when is_function(FieldSchema, 1) ->
     FieldSchema(SchemaKey);
-field_schema(#{type := _} = FieldSchema, SchemaKey) ->
+field_schema(FieldSchema, SchemaKey) when is_map(FieldSchema) ->
     maps:get(SchemaKey, FieldSchema, undefined).
 
 maybe_mapping(undefined, _) -> []; % no mapping defined for this field

--- a/src/hocon_schema_doc.erl
+++ b/src/hocon_schema_doc.erl
@@ -52,6 +52,8 @@ find_structs_per_type(Schema, ?UNION(Types), Acc) ->
     lists:foldl(fun(T, AccIn) ->
                         find_structs_per_type(Schema, T, AccIn)
                 end, Acc, Types);
+find_structs_per_type(Schema, ?MAP(_Name, Type), Acc) ->
+    find_structs_per_type(Schema, Type, Acc);
 find_structs_per_type(_Schema, _Type, Acc) ->
     Acc.
 
@@ -116,6 +118,7 @@ do_type(Ns, ?ARRAY(T)) -> io_lib:format("[~s]", [do_type(Ns, T)]);
 do_type(Ns, ?UNION(Ts)) -> lists:join(" | ", [do_type(Ns, T) || T <- Ts]);
 do_type(_Ns, ?ENUM(Symbols)) -> lists:join(" | ", [bin(S) || S <- Symbols]);
 do_type(Ns, ?LAZY(T)) -> do_type(Ns, T);
+do_type(Ns, ?MAP(Name, T)) -> ["{$", bin(Name), " -> ", do_type(Ns, T), "}"];
 do_type(_Ns, {'$type_refl', #{name := Type}}) -> lists:flatten(Type).
 
 ref(undefined, Name) -> Name;

--- a/src/hoconsc.erl
+++ b/src/hoconsc.erl
@@ -20,7 +20,7 @@
 -export([mk/1, mk/2]).
 -export([ref/1, ref/2]).
 -export([array/1, union/1, enum/1]).
--export([lazy/1]).
+-export([lazy/1, map/2]).
 
 -include("hoconsc.hrl").
 
@@ -49,6 +49,8 @@ union(OfTypes) when is_list(OfTypes) -> ?UNION(OfTypes).
 enum(OfSymbols) when is_list(OfSymbols) -> ?ENUM(OfSymbols).
 
 lazy(HintType) -> ?LAZY(HintType).
+
+map(Name, Type) -> ?MAP(Name, Type).
 
 assert_type(S) when is_function(S) -> error({expecting_type_but_got_schema, S});
 assert_type(#{type := _} = S) -> error({expecting_type_but_got_schema, S});

--- a/test/hocon_schema_doc_tests.erl
+++ b/test/hocon_schema_doc_tests.erl
@@ -29,7 +29,7 @@ no_crash_test_() ->
      {"arbitrary2",
       gen(#{namespace => dummy,
             roots => [foo],
-            fields => #{foo => [{"f1", hoconsc:mk(hoconsc:ref(emqx_schema, "zone_settings"))}]}
+            fields => #{foo => [{"f1", hoconsc:mk(hoconsc:ref(emqx_schema, "zone"))}]}
            })}
     ].
 

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -733,7 +733,7 @@ root_array_test_() ->
 
 ref_nullable_test() ->
     Sc = #{roots => [ {k, #{type => hoconsc:ref(sub),
-                              nullable => {true, recursively}}}
+                            nullable => {true, recursively}}}
                     , {x, string()}
                     ],
            fields =>  #{sub => [{a, string()}, {b, string()}]}
@@ -741,7 +741,16 @@ ref_nullable_test() ->
     Conf = "x = y",
     {ok, RichMap} = hocon:binary(Conf, #{format => richmap}),
     ?assertEqual(#{<<"x">> => "y"},
-                 hocon_schema:richmap_to_map(hocon_schema:check(Sc, RichMap))).
+                 hocon_schema:richmap_to_map(hocon_schema:check(Sc, RichMap))),
+    {ok, Map} = hocon:binary("k = null, x = y", #{format => map}),
+    ?assertEqual(#{<<"x">> => "y"}, hocon_schema:check_plain(Sc, Map)),
+    with_envs(
+      fun() ->
+            {ok, Map2} = hocon:binary("k = {a: a, b: b}, x = y", #{format => map}),
+            ?assertEqual(#{<<"x">> => "y"}, hocon_schema:check_plain(Sc, Map2))
+      end, [{"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"},
+            {"EMQX_K", "null"}
+           ]).
 
 lazy_test() ->
     Sc = #{roots => [ {k, #{type => hoconsc:lazy(integer())}}


### PR DESCRIPTION
prior to this pr, we had to use single-filed structs like `[{$name, Schema}]` to support `map`-like types
i.e. a struct without pre-defined field names.

it worked fine, but it's a bit hard to declare as you'd need to define an extra level of reference field/type
and it's ugly in generated document.

this PR adds a `hoconsc:map/2` type to simplify schema definition also to beautify the generated doc.

example doc:
![image](https://user-images.githubusercontent.com/164324/132088493-c802ddc9-a9c4-4f8b-ab65-65d79a260621.png)
