### PR TITLE
fix(schema): fill defaults with binary string

### DIFF
--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -675,7 +675,7 @@ default_value_for_null_enclosing_struct_test() ->
     ?assertEqual(#{<<"l1">> => #{<<"l2">> => 22}},
                  hocon_schema:check(Sc, RichMap, #{nullable => true, return_plain => true})).
 
-fill_defaults_test() ->
+fill_primitive_defaults_test() ->
     Sc = #{roots => ["a"],
            fields => #{"a" =>
                [ {b, hoconsc:mk(integer(), #{default => 888})}
@@ -687,8 +687,21 @@ fill_defaults_test() ->
           },
     ?assertMatch(#{<<"a">> := #{<<"b">> := 888, <<"c">> := 15000, <<"d">> := 16}},
         hocon_schema:check_plain(Sc, #{}, #{nullable => true})),
-    ?assertMatch(#{<<"a">> := #{<<"b">> := 888, <<"c">> := "15s", <<"d">> := <<"16">>}},
+    ?assertMatch(#{<<"a">> := #{<<"b">> := 888, <<"c">> := <<"15s">>, <<"d">> := <<"16">>}},
         hocon_schema:check_plain(Sc, #{}, #{nullable => true, only_fill_defaults => true})),
+    ok.
+
+fill_complex_defaults_test() ->
+    Sc = #{roots => [{"a", hoconsc:mk(hoconsc:ref("sub"),
+                                      #{default => #{<<"c">> => 2, <<"d">> => [90, 91, 92]}})}],
+           fields => #{"sub" =>
+               [ {"c", hoconsc:mk(integer())}
+               , {"d", hoconsc:mk(hoconsc:array(integer()))}
+               ]}
+          },
+    %% ensure integer array is not converted to a string
+    ?assertMatch(#{<<"a">> := #{<<"c">> := 2, <<"d">> := [90, 91, 92]}},
+        hocon_schema:check_plain(Sc, #{}, #{only_fill_defaults => true})),
     ok.
 
 root_array_test_() ->


### PR DESCRIPTION
In `hocon:load` result, strings are `binary()`, after type-check for `string()` type, it's value is converted from `binary()` to `string()`.
However, `hocon_schema`'s type-check is on-way,
i.e. can only be parsed(converted), but it's impossible to format parsed value back to HOCON format.
--- not only string and binary, but also the values from `converter`.

In case one wants to 'dry-run' the type-check without conversion, they can just discard the parsed result.
However, we may sometimes want to fill in default values for the raw input, this is what `only_fill_defaults` option designed for.

Prior to this PR, defaults are filled as-is, causing the filled HOCON value incompatible to JSON encoders which only accepts binary for strings.
This PR makes sure when filling in a primitive type value, when it's a printable unicode string, we try to make it a binary.