### PR TITLE
Feat support apply envs without defatuls

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -192,12 +192,12 @@ HOCON schema also supports below field metadata.
   the value is as expected. NOTE: the input to validator after convert (if present) is applied.
 * `default`: default value of the field. NOTE that default values are to be treated as raw inputs,
   meaning they are put hrough  the `converter`s and `validator`s etc, and then type-checked.
-* `override_env`: special environment variable name to override this field value.
-  NOTE: For generic override, see [below](#default_override_rule) for more info
 * `nullable`: set to `true` if this field is allowed to be `undefined`.
   NOTE: there is no point setting it to `true` if fields has a default value.
 * `sensitive`: set to `true` if this field's value is sensitive so we will obfuscate the log
   with `********` when logging.
+* `desc`: text for document generation
+* `hidden`: a boolean flag to hide it from appearing in config document
 
 <a name="default_override_rule"></a>
 

--- a/sample-schemas/demo_schema.erl
+++ b/sample-schemas/demo_schema.erl
@@ -79,7 +79,6 @@ translation("app_foo") ->
 
 setting(mapping) -> "app_foo.setting";
 setting(type) -> string();
-setting(override_env) -> "MY_OVERRIDE";
 setting(_) -> undefined.
 
 range(Conf) ->

--- a/sample-schemas/demo_schema3.erl
+++ b/sample-schemas/demo_schema3.erl
@@ -20,15 +20,24 @@
 
 -export([namespace/0, roots/0, fields/1]).
 
-namespace() -> undefined.
+namespace() -> ?MODULE.
 
 roots() ->
     [ {foo, hoconsc:array(hoconsc:ref(foo))}
+    , {bar, hoconsc:ref(parent)}
     ].
 
 fields(foo) ->
     [ {bar, hoconsc:ref(bar)}
     ];
 fields(bar) ->
-    Sc = hoconsc:union([hoconsc:ref(foo), null]),
-    [{"baz", Sc}].
+    Sc = hoconsc:union([hoconsc:ref(foo), null]), %% cyclic refs
+    [{"baz", Sc}];
+%% below fields are to cover the test where identical paths for the same name
+%% i.e. bar.f1.subf.baz can be reached from both "sub1" and "sub2"
+fields(parent) ->
+    [{"f1", hoconsc:union([hoconsc:ref("sub1"), hoconsc:ref("sub2")])}];
+fields("sub1") ->
+    [{"sub_f", hoconsc:ref(bar)}]; %% both sub1 and sub2 refs to bar
+fields("sub2") ->
+    [{"sub_f", hoconsc:ref(bar)}]. %% both sub1 and sub2 refs to bar

--- a/sample-schemas/emqx_schema.erl
+++ b/sample-schemas/emqx_schema.erl
@@ -34,7 +34,7 @@
                 comma_separated_list/0, bar_separated_list/0, ip_port/0]).
 
 -export([roots/0, fields/1, translations/0, translation/1]).
--export([t/1, t/3, t/4, ref/1]).
+-export([t/1, t/3, ref/1]).
 -export([conf_get/2, conf_get/3, keys/2, filter/1]).
 -export([ssl/2, tr_ssl/2, tr_password_hash/2]).
 
@@ -96,14 +96,14 @@ fields("k8s") ->
     ];
 
 fields("node") ->
-    [ {"name", t(string(), "vm_args.-name", "emqx@127.0.0.1", "NODE_NAME")}
+    [ {"name", t(string(), "vm_args.-name", "emqx@127.0.0.1")}
     , {"ssl_dist_optfile", t(string(), "vm_args.-ssl_dist_optfile", undefined)}
-    , {"cookie", t(string(), "vm_args.-setcookie", "emqxsecretcookie", "NODE_COOKIE")}
+    , {"cookie", t(string(), "vm_args.-setcookie", "emqxsecretcookie")}
     , {"data_dir", t(string(), "emqx.data_dir", undefined)}
     , {"heartbeat", t(flag(), undefined, false)}
     , {"async_threads", t(range(1, 1024), "vm_args.+A", undefined)}
     , {"process_limit", t(integer(), "vm_args.+P", undefined)}
-    , {"max_ports", t(range(1024, 134217727), "vm_args.+Q", undefined, "MAX_PORTS")}
+    , {"max_ports", t(range(1024, 134217727), "vm_args.+Q", undefined)}
     , {"dist_buffer_size", fun node__dist_buffer_size/1}
     , {"global_gc_interval", t(duration_s(), "emqx.global_gc_interval", undefined)}
     , {"fullsweep_after", t(non_neg_integer(),
@@ -194,7 +194,7 @@ fields("acl") ->
     ];
 
 fields("mqtt") ->
-    [ {"max_packet_size", t(bytesize(), "emqx.max_packet_size", "1MB", "MAX_PACKET_SIZE")}
+    [ {"max_packet_size", t(bytesize(), "emqx.max_packet_size", "1MB")}
     , {"max_clientid_len", t(integer(), "emqx.max_clientid_len", 65535)}
     , {"max_topic_levels", t(integer(), "emqx.max_topic_levels", 0)}
     , {"max_qos_allowed", t(range(0, 2), "emqx.max_qos_allowed", 2)}
@@ -1153,13 +1153,6 @@ t(T) ->
 
 t(T, M, D) ->
     fun (type) -> T; (mapping) -> M; (default) -> D; (_) -> undefined end.
-
-t(T, M, D, O) ->
-    fun (type) -> T;
-        (mapping) -> M;
-        (default) -> D;
-        (override_env) -> O;
-        (_) -> undefined end.
 
 ref(Field) ->
     fun (type) -> Field; (_) -> undefined end.

--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -143,8 +143,8 @@ get(ParsedArgs, [Query | _]) ->
     [RootName0 | _] = string:tokens(Query, "."),
     RootName = hocon_schema:resolve_struct_name(Schema, RootName0),
     %% do not log anything for `get` commands
-    DummyLogger = #{logger => fun(_, _) -> ok end},
-    {_, NewConf} = hocon_schema:map(Schema, Conf, [RootName], DummyLogger),
+    Opts = #{logger => fun(_, _) -> ok end, apply_override_envs => true},
+    {_, NewConf} = hocon_schema:map(Schema, Conf, [RootName], Opts),
     ?STDOUT("~0p", [hocon_schema:get_value(Query, NewConf)]),
     stop_ok().
 
@@ -251,7 +251,8 @@ generate(ParsedArgs) ->
                  true -> fun log_for_generator/2;
                  false -> fun(_, _) -> ok end
              end,
-    try hocon_schema:generate(Schema, Conf, #{logger => LogFun}) of
+    Opts = #{logger => LogFun, apply_override_envs => true},
+    try hocon_schema:generate(Schema, Conf, Opts) of
         NewConfig ->
             AppConfig = proplists:delete(vm_args, NewConfig),
             VmArgs = stringify(proplists:get_value(vm_args, NewConfig)),

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -1353,7 +1353,7 @@ find_structs_per_type(_Schema, ?R_REF(Module, Name), Acc, Stack, TStack) ->
 find_structs_per_type(Schema, ?LAZY(Type), Acc, Stack, TStack) ->
     find_structs_per_type(Schema, Type, Acc, Stack, TStack);
 find_structs_per_type(Schema, ?ARRAY(Type), Acc, Stack, TStack) ->
-    find_structs_per_type(Schema, Type, Acc, ["$I" | Stack], TStack);
+    find_structs_per_type(Schema, Type, Acc, ["$INDEX" | Stack], TStack);
 find_structs_per_type(Schema, ?UNION(Types), Acc, Stack, TStack) ->
     lists:foldl(fun(T, AccIn) ->
                         find_structs_per_type(Schema, T, AccIn, Stack, TStack)

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -1388,20 +1388,14 @@ find_ref(Schema, Name, Acc, Stack, TStack) ->
             {ok, #{paths := Ps}} -> Ps;
             error -> #{}
         end,
-    case maps:is_key(Path, Paths) of
+    case lists:member(Key, TStack) of
         true ->
-            %% found it before
+            %% loop reference, break here, otherwise never exit
             Acc;
         false ->
-            case lists:member(Key, TStack) of
-                true ->
-                    %% loop reference
-                    Acc;
-                false ->
-                    Fields0 = fields_and_meta(Schema, Name),
-                    Fields = Fields0#{paths => Paths#{Path => true}},
-                    find_structs(Schema, Fields, Acc#{Key => Fields}, Stack, [Key | TStack])
-            end
+            Fields0 = fields_and_meta(Schema, Name),
+            Fields = Fields0#{paths => Paths#{Path => true}},
+            find_structs(Schema, Fields, Acc#{Key => Fields}, Stack, [Key | TStack])
     end.
 
 only_fill_defaults(#{only_fill_defaults := true}) -> true;

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -27,7 +27,6 @@
         , validations/1
         ]).
 
-
 -export([map/2, map/3, map/4]).
 -export([translate/3]).
 -export([generate/2, generate/3, map_translate/3]).
@@ -192,14 +191,17 @@ roots(Schema) ->
         {RootNs :: name(), RootFields :: [field()],
          [{Namespace :: name(), Name :: name(), fields()}]}.
 find_structs(Schema) ->
-    Roots = ?MODULE:roots(Schema),
-    RootFields = lists:map(fun({_BinName, {RootFieldName, RootFieldSchema}}) ->
-                                   {RootFieldName, RootFieldSchema}
-                           end, Roots),
+    RootFields = unify_roots(Schema),
     All = find_structs(Schema, RootFields),
     RootNs = hocon_schema:namespace(Schema),
     {RootNs, RootFields,
      [{Ns, Name, Fields} || {{Ns, Name}, Fields} <- lists:keysort(1, maps:to_list(All))]}.
+
+unify_roots(Schema) ->
+    Roots = ?MODULE:roots(Schema),
+    lists:map(fun({_BinName, {RootFieldName, RootFieldSchema}}) ->
+                      {RootFieldName, RootFieldSchema}
+              end, Roots).
 
 do_roots(Mod) when is_atom(Mod) -> Mod:roots();
 do_roots(#{roots := Names}) -> Names.
@@ -367,7 +369,7 @@ merge_opts(Default, Opts0) ->
     %% use `apply_override_envs' instead
     Override = case maps:get(override_env, Opts0, undefined) of
                    undefined ->
-                       maps:get(apply_override_envs, Opts0, true);
+                       maps:get(apply_override_envs, Opts0, false);
                    Bool when is_boolean(Bool) ->
                        Bool
                end,
@@ -442,7 +444,7 @@ map(Schema, Conf0, Roots0, Opts0) ->
                           ok = assert_no_dot(Schema, RootName)
                   end, Roots),
     Conf1 = filter_by_roots(Opts, Conf0, Roots),
-    Conf = apply_envs(Conf1, Opts, Roots),
+    Conf = apply_envs(Schema, Conf1, Opts, Roots),
     {Mapped0, NewConf} = do_map(Roots, Conf, Opts, ?MAGIC_SCHEMA),
     ok = assert_no_error(Schema, Mapped0),
     ok = assert_integrity(Schema, NewConf, Opts),
@@ -461,12 +463,12 @@ log_and_drop_env_overrides(Opts, [H | T]) ->
 %% fields, however it is more complicated than the current approach
 %% because, for nullable fields, we may skip over the struct schema,
 %% meaning override only works if the object existed in the input Conf.
-apply_envs(Conf, Opts, Roots) ->
-    {EnvNamespace, Envs} = collect_envs(Opts),
-    apply_envs(EnvNamespace, Envs, Opts, Roots, Conf).
+apply_envs(Schema, Conf, Opts, Roots) ->
+    {EnvNamespace, Envs} = collect_envs(Schema, Opts, Roots),
+    do_apply_envs(EnvNamespace, Envs, Opts, Roots, Conf).
 
-apply_envs(_EnvNamespace, _Envs, _Opts, [], Conf) -> Conf;
-apply_envs(EnvNamespace, Envs, Opts, [{RootName, RootSc} | Roots], Conf) ->
+do_apply_envs(_EnvNamespace, _Envs, _Opts, [], Conf) -> Conf;
+do_apply_envs(EnvNamespace, Envs, Opts, [{RootName, RootSc} | Roots], Conf) ->
     ShouldApply =
         case field_schema(RootSc, type) of
             ?LAZY(_) -> maps:get(check_lazy, Opts, false);
@@ -476,7 +478,7 @@ apply_envs(EnvNamespace, Envs, Opts, [{RootName, RootSc} | Roots], Conf) ->
                   true -> apply_env(EnvNamespace, Envs, RootName, Conf, Opts);
                   false -> Conf
                 end,
-    apply_envs(EnvNamespace, Envs, Opts, Roots, NewConf).
+    do_apply_envs(EnvNamespace, Envs, Opts, Roots, NewConf).
 
 %% silently drop unknown data (root level only)
 filter_by_roots(Opts, Conf, Roots) ->
@@ -724,7 +726,7 @@ maps_keys(undefined) -> [];
 maps_keys(Map) -> maps:keys(Map).
 
 check_unknown_fields(Opts, SchemaFieldNames, DataFields) ->
-    case find_unknown_fields(Opts, SchemaFieldNames, DataFields) of
+    case find_unknown_fields(SchemaFieldNames, DataFields) of
         [] ->
             ok;
         Unknowns ->
@@ -736,11 +738,11 @@ check_unknown_fields(Opts, SchemaFieldNames, DataFields) ->
             validation_errs(Opts, Err)
     end.
 
-find_unknown_fields(_Opts, _SchemaFieldNames, undefined) -> [];
-find_unknown_fields(Opts, SchemaFieldNames0, DataFields) ->
+find_unknown_fields(_SchemaFieldNames, undefined) -> [];
+find_unknown_fields(SchemaFieldNames0, DataFields) ->
     SchemaFieldNames = lists:map(fun bin/1, SchemaFieldNames0),
     maps:fold(fun(DfName, DfValue, Acc) ->
-                      case is_known_field(Opts, DfName, DfValue, SchemaFieldNames) of
+                      case is_known_name(DfName, SchemaFieldNames) of
                           true ->
                               Acc;
                           false ->
@@ -751,16 +753,6 @@ find_unknown_fields(Opts, SchemaFieldNames0, DataFields) ->
                               [Unknown | Acc]
                       end
               end, [], DataFields).
-
-is_known_field(Opts, Name, Value, ExpectedNames) ->
-    is_known_name(Name, ExpectedNames) orelse
-    case Value of
-        #{?HOCON_V := ?FROM_ENV_VAR(EnvName, _)} ->
-            log(Opts, warning, bin(["unknown_environment_variable_discarded: ", EnvName])),
-            true;
-        _ ->
-            false
-    end.
 
 is_known_name(Name, ExpectedNames) ->
     lists:any(fun(N) -> N =:= bin(Name) end, ExpectedNames).
@@ -856,19 +848,89 @@ maybe_use_default(Default, undefined, Opts) ->
     maybe_mkrich(Opts, Default, ?META_BOX(made_for, default_value));
 maybe_use_default(_, Value, _Opts) -> Value.
 
-collect_envs(#{apply_override_envs := false}) -> {undefined, []};
-collect_envs(Opts) ->
+collect_envs(_, #{apply_override_envs := false}, _) ->
+    {undefined, []};
+collect_envs(Schema, Opts, Roots) ->
     Ns = hocon_util:env_prefix(_Default = undefined),
     case Ns of
         undefined -> {undefined, []};
-        _ -> {Ns, lists:keysort(1, collect_envs(Ns, Opts))}
+        _ -> {Ns, lists:keysort(1, collect_envs(Schema, Ns, Opts, Roots))}
     end.
 
-collect_envs(Ns, Opts) ->
-    [begin
-         [Name, Value] = string:split(KV, "="),
-         {Name, read_hocon_val(Value, Opts)}
-     end || KV <- os:getenv(), string:prefix(KV, Ns) =/= nomatch].
+collect_envs(Schema, Ns, Opts, Roots) ->
+    Pairs = [begin
+                 [Name, Value] = string:split(KV, "="),
+                 {Name, Value}
+             end || KV <- os:getenv(), string:prefix(KV, Ns) =/= nomatch],
+    {Matched, Unknown} =
+        lists:partition(fun({N, _}) -> is_known_env(Schema, Roots, Ns, N) end, Pairs),
+    case Unknown =/= [] of
+        true ->
+            UnknownVars = lists:sort([N || {N, _} <- Unknown]),
+            Msg = bin(io_lib:format("unknown_env_vars: ~p", [UnknownVars])),
+            log(Opts, warning, Msg);
+        false ->
+            ok
+    end,
+    [{Name, read_hocon_val(Value, Opts)} || {Name, Value} <- Matched].
+
+is_known_env(Schema, Roots, Ns, EnvVarName) ->
+    case env_name_to_path(Ns, EnvVarName) of
+        false ->
+            false;
+        [RootName | Path] ->
+            case is_field(Roots, RootName) of
+                {true, Type} -> is_path(Schema, Type, Path);
+                false -> false
+            end
+    end.
+
+is_field([], _Name) -> false;
+is_field([{FN, FT} | Fields], Name) ->
+    case bin(FN) =:= bin(Name) of
+        true ->
+            Type = hocon_schema:field_schema(FT, type),
+            {true, Type};
+        false ->
+            is_field(Fields, Name)
+    end.
+
+is_path(_Schema, _Name, []) -> true;
+is_path(Schema, Name, Path) when is_list(Name) ->
+    is_path2(Schema, Name, Path);
+is_path(Schema, ?REF(Name), Path) ->
+    is_path2(Schema, Name, Path);
+is_path(_Schema, ?R_REF(Module, Name), Path) ->
+    is_path2(Module, Name, Path);
+is_path(Schema, ?LAZY(Type), Path) ->
+    is_path(Schema, Type, Path);
+is_path(Schema, ?ARRAY(Type), [Name | Path]) ->
+    case is_array_index(Name) of
+        {true, _} -> is_path(Schema, Type, Path);
+        false -> false
+    end;
+is_path(Schema, ?UNION(Types), Path) ->
+    lists:any(fun(T) -> is_path(Schema, T, Path) end, Types);
+is_path(Schema, ?MAP(_, Type), [_ | Path]) ->
+    is_path(Schema, Type, Path);
+is_path(_Schema, _Type, _Path) ->
+    false.
+
+is_path2(Schema, RefName, [Name | Path]) ->
+    Fields = fields(Schema, RefName),
+    case is_field(Fields, Name) of
+        {true, Type} -> is_path(Schema, Type, Path);
+        false -> false
+    end.
+
+%% EMQX_FOO__BAR -> ["foo", "bar"]
+env_name_to_path(Ns, VarName) ->
+    K = string:prefix(VarName, Ns),
+    Path0 = string:split(string:lowercase(K), "__", all),
+    case lists:filter(fun(N) -> N =/= [] end, Path0) of
+        [] -> false;
+        Path -> Path
+    end.
 
 read_hocon_val("", _Opts) -> "";
 read_hocon_val(Value, Opts) ->
@@ -891,13 +953,12 @@ read_informal_hocon_val(Value, Opts) ->
 
 apply_env(_Ns, [], _RootName, Conf, _Opts) -> Conf;
 apply_env(Ns, [{VarName, V} | More], RootName, Conf, Opts) ->
-    K = string:prefix(VarName, Ns),
-    Path0 = string:split(string:lowercase(K), "__", all),
-    Path1 = lists:filter(fun(N) -> N =/= [] end, Path0),
+    %% match [_ | _] here because the name is already validated
+    [_ | _] = Path0 = env_name_to_path(Ns, VarName),
     NewConf =
-        case Path1 =/= [] andalso bin(RootName) =:= bin(hd(Path1)) of
+        case Path0 =/= [] andalso bin(RootName) =:= bin(hd(Path0)) of
             true ->
-                Path = string:join(Path1, "."),
+                Path = string:join(Path0, "."),
                 %% It lacks schema info here, so we need to tag the value '$FROM_ENV_VAR'
                 %% and the value will be logged later when checking against schema
                 %% so we know if the value is sensitive or not.
@@ -1171,6 +1232,8 @@ update_map_field(Opts, Map, FieldName, GoDeep) ->
     Map1 = maps:without([FieldName], Map),
     Map1#{maybe_atom(Opts, FieldName) => FieldV}.
 
+is_array_index(L) when is_list(L) ->
+    is_array_index(list_to_binary(L));
 is_array_index(I) ->
     try
         {true, binary_to_integer(I)}

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -1187,28 +1187,7 @@ maybe_array(V) -> V =:= ?EMPTY_MAP.
 update_array_element(?EMPTY_MAP, Index, GoDeep) ->
     update_array_element([], Index, GoDeep);
 update_array_element(List, Index, GoDeep) when is_list(List) ->
-    MinIndex = 1,
-    MaxIndex = length(List) + 1,
-    Index < MinIndex andalso throw({bad_array_index, "index starts from 1"}),
-    Index > MaxIndex andalso
-    begin
-        Msg0 = io_lib:format("should not be greater than ~p.", [MaxIndex]),
-        Msg1 = case Index > 9 of
-                   true ->
-                       "~nEnvironment variable overrides applied in alphabetical "
-                       "make sure to use zero paddings such as '02' to ensure "
-                       "10 is ordered after it";
-                   false ->
-                       []
-               end,
-        throw({bad_array_index, [Msg0, Msg1]})
-    end,
-    {Head, Tail0} = lists:split(Index - 1, List),
-    {Nth, Tail} = case Tail0 of
-                      [] -> {?EMPTY_MAP, []};
-                      [H | T] -> {H, T}
-                  end,
-    Head ++ [GoDeep(Nth) | Tail].
+    hocon_util:update_array_element(List, Index, GoDeep).
 
 update_map_field(Opts, Map, FieldName, GoDeep) ->
     FieldV0 = maps:get(FieldName, Map, ?EMPTY_MAP),
@@ -1216,15 +1195,10 @@ update_map_field(Opts, Map, FieldName, GoDeep) ->
     Map1 = maps:without([FieldName], Map),
     Map1#{maybe_atom(Opts, FieldName) => FieldV}.
 
+%% {true, integer()} if yes, otherwise false
 is_array_index(L) when is_list(L) ->
     is_array_index(list_to_binary(L));
-is_array_index(I) ->
-    try
-        {true, binary_to_integer(I)}
-    catch
-        _ : _ ->
-            false
-    end.
+is_array_index(I) -> hocon_util:is_array_index(I).
 
 check_indexed_array(List) ->
     case check_indexed_array(List, [], []) of

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -196,7 +196,7 @@ find_structs(Schema) ->
     RootFields = lists:map(fun({_BinName, {RootFieldName, RootFieldSchema}}) ->
                                    {RootFieldName, RootFieldSchema}
                            end, Roots),
-    All = find_structs(Schema, RootFields, #{}, _ValueStack = [], _TypeStack = []),
+    All = find_structs(Schema, RootFields),
     RootNs = hocon_schema:namespace(Schema),
     {RootNs, RootFields,
      [{Ns, Name, Fields} || {{Ns, Name}, Fields} <- lists:keysort(1, maps:to_list(All))]}.
@@ -1285,6 +1285,9 @@ do_find_error([{error, E} | More], Errors) ->
     do_find_error(More, [E | Errors]);
 do_find_error([_ | More], Errors) ->
     do_find_error(More, Errors).
+
+find_structs(Schema, Fields) ->
+    find_structs(Schema, Fields, #{}, _ValueStack = [], _TypeStack = []).
 
 find_structs(Schema, #{fields := Fields}, Acc, Stack, TStack) ->
     find_structs(Schema, Fields, Acc, Stack, TStack);

--- a/src/hocon_schema_doc.erl
+++ b/src/hocon_schema_doc.erl
@@ -22,11 +22,17 @@
 -include("hocon_private.hrl").
 
 gen(Schema, undefined) ->
-    gen(Schema, "HOCON Document");
-gen(Schema, Title) ->
+    gen(Schema, "# HOCON Document");
+gen(Schema, Title) when is_list(Title) orelse is_binary(Title) ->
+    gen(Schema, #{title => Title, body => <<>>});
+gen(Schema, #{title := Title, body := Body}) ->
     {RootNs, RootFields, Structs} = hocon_schema:find_structs(Schema),
-    [fmt_structs(1, RootNs, [{RootNs, Title, #{fields => RootFields}}]),
-     fmt_structs(2, RootNs, Structs)].
+    [Title,
+     "\n",
+     Body,
+     "\n",
+     fmt_structs(2, RootNs, [{RootNs, "Root Config Keys", #{fields => RootFields}}]),
+     fmt_structs(3, RootNs, Structs)].
 
 fmt_structs(_HeadWeight, _RootNs, []) -> [];
 fmt_structs(HeadWeight, RootNs, [{Ns, Name, Fields} | Rest]) ->

--- a/src/hocon_util.erl
+++ b/src/hocon_util.erl
@@ -16,26 +16,53 @@
 
 -module(hocon_util).
 
--export([deep_merge/2]).
+-export([deep_map_merge/2, deep_merge/2]).
 -export([pipeline_fun/1, pipeline/3]).
 -export([stack_multiple_push/2, stack_push/2, get_stack/2, top_stack/2]).
 -export([is_same_file/2, real_file_name/1]).
 -export([richmap_to_map/1]).
--export([env_prefix/1]).
+-export([env_prefix/1, is_array_index/1]).
+-export([update_array_element/3]).
 
 -include("hocon_private.hrl").
 
-deep_merge(M1, M2) when is_map(M1), is_map(M2) ->
-    maps:fold(fun(K, V2, Acc) ->
-        case Acc of
-            #{K := V1} ->
-                Acc#{K => deep_merge(V1, V2)};
-            _ ->
-                Acc#{K => V2}
-        end
-              end, M1, M2);
-deep_merge(_, Override) ->
+deep_map_merge(M1, M2) when is_map(M1), is_map(M2) ->
+    do_deep_merge(M1, M2, fun deep_map_merge/2);
+deep_map_merge(_, Override) ->
     Override.
+
+do_deep_merge(M1, M2, GoDeep) when is_map(M1), is_map(M2) ->
+    maps:fold(
+        fun(K, V2, Acc) ->
+                V1 = maps:get(K, Acc, undefined),
+                NewV = do_deep_merge(V1, V2, GoDeep),
+                Acc#{K => NewV}
+        end, M1, M2);
+do_deep_merge(V1, V2, GoDeep) ->
+    GoDeep(V1, V2).
+
+deep_merge(#{?HOCON_T := array, ?HOCON_V := V1} = Base,
+                 #{?HOCON_T := object, ?HOCON_V := V2} = Top) ->
+    NewV = deep_merge2(V1, V2),
+    case is_list(NewV) of
+        true ->
+            %% after merge, it's still an array, only update the value
+            %% keep the metadata
+            Base#{?HOCON_V => NewV};
+        false ->
+            %% after merge, it's no longer an array, return all old
+            Top
+    end;
+deep_merge(V1, V2) ->
+    deep_merge2(V1, V2).
+
+deep_merge2(M1, M2) when is_map(M1) andalso is_map(M2) ->
+    do_deep_merge(M1, M2, fun deep_merge/2);
+deep_merge2(V1, V2) ->
+    case is_list(V1) andalso is_indexed_array(V2) of
+        true -> merge_array(V1, V2);
+        false -> V2
+    end.
 
 pipeline_fun(Steps) ->
     fun (Input) -> pipeline(Input, #{}, Steps) end.
@@ -98,3 +125,62 @@ env_prefix(Default) ->
         V when V =:= false orelse V =:= [] -> Default;
         Prefix -> Prefix
     end.
+
+is_array_index(I) when is_binary(I) ->
+    try
+        {true, binary_to_integer(I)}
+    catch
+        _ : _ ->
+            false
+    end.
+
+is_indexed_array(M) when is_map(M) ->
+    lists:all(fun(K) -> case is_array_index(K) of
+                            {true, _} -> true;
+                            _ -> false
+                        end
+              end, maps:keys(M));
+is_indexed_array(_) ->
+    false.
+
+%% convert indexed array to key-sorted tuple {index, value} list
+indexed_array_as_list(M) when is_map(M) ->
+    lists:keysort(
+      1, lists:map(fun({K, V}) ->
+                           {true, I} = is_array_index(K),
+                           {I, V}
+                   end, maps:to_list(M))).
+
+merge_array(Array, Top) when is_list(Array) ->
+    ToMerge = indexed_array_as_list(Top),
+    do_merge_array(Array, ToMerge).
+
+do_merge_array(Array, []) -> Array;
+do_merge_array(Array, [{I, Value} | Rest]) ->
+    GoDeep = fun(Elem) -> deep_merge(Elem, Value) end,
+    NewArray = update_array_element(Array, I, GoDeep),
+    do_merge_array(NewArray, Rest).
+
+update_array_element(List, Index, GoDeep) when is_list(List) ->
+    MinIndex = 1,
+    MaxIndex = length(List) + 1,
+    Index < MinIndex andalso throw({bad_array_index, "index starts from 1"}),
+    Index > MaxIndex andalso
+    begin
+        Msg0 = io_lib:format("should not be greater than ~p.", [MaxIndex]),
+        Msg1 = case Index > 9 of
+                   true ->
+                       "~nEnvironment variable overrides applied in alphabetical "
+                       "make sure to use zero paddings such as '02' to ensure "
+                       "10 is ordered after it";
+                   false ->
+                       []
+               end,
+        throw({bad_array_index, [Msg0, Msg1]})
+    end,
+    {Head, Tail0} = lists:split(Index - 1, List),
+    {Nth, Tail} = case Tail0 of
+                      [] -> {#{}, []};
+                      [H | T] -> {H, T}
+                  end,
+    Head ++ [GoDeep(Nth) | Tail].

--- a/test/hocon_schema_doc_tests.erl
+++ b/test/hocon_schema_doc_tests.erl
@@ -35,3 +35,12 @@ no_crash_test_() ->
     ].
 
 gen(Schema) -> fun() -> hocon_schema_doc:gen(Schema, "test") end.
+
+find_structs_test() ->
+    {demo_schema3, _Roots, Subs} = hocon_schema:find_structs(demo_schema3),
+    Find = fun(N) -> is_tuple(lists:keyfind(N, 2, Subs)) end,
+    ?assert(Find(bar)),
+    ?assert(Find(foo)),
+    ?assert(Find(parent)),
+    ?assert(Find("sub1")),
+    ?assert(Find("sub2")).

--- a/test/hocon_schema_tests.erl
+++ b/test/hocon_schema_tests.erl
@@ -64,7 +64,7 @@ union_with_default(_) -> undefined.
 
 default_value_test() ->
     Conf = "{\"bar.field1\": \"foo\"}",
-    Res = check(Conf),
+    Res = check(Conf, #{format => richmap}),
     ?assertEqual(Res, check_plain(Conf)),
     ?assertEqual(#{<<"bar">> => #{ <<"union_with_default">> => dummy,
                                    <<"field1">> => "foo"}}, Res).
@@ -73,8 +73,10 @@ env_override_test() ->
     with_envs(
       fun() ->
               Conf = "{\"bar.field1\": \"foo\"}",
-              Res = check(Conf),
-              ?assertEqual(Res, check_plain(Conf, #{logger => fun(_, _) -> ok end})),
+              Res = check(Conf, #{format => richmap, apply_override_envs => true}),
+              ?assertEqual(Res, check_plain(Conf, #{logger => fun(_, _) -> ok end,
+                                                    apply_override_envs => true
+                                                   })),
               ?assertEqual(#{<<"bar">> => #{ <<"union_with_default">> => #{<<"val">> => 111},
                                              <<"field1">> => ""}}, Res)
       end, [{"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"},
@@ -108,23 +110,30 @@ unknown_env_test() ->
                                  end
                       },
               {ok, RichMap} = hocon:binary(Conf, #{format => richmap}),
-              hocon_schema:check(?MODULE, RichMap, Opts)
-      end, [{"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"},
-            {"EMQX_BAR__UNION_WITH_DEFAULT__VAL", "111"},
-            {"EMQX_bar__field1", ""},
-            {"EMQX_BAR__UNKNOWNx", "x"}
-           ]),
+              hocon_schema:check(?MODULE, RichMap, Opts#{apply_override_envs => true})
+      end,
+      envs([ {"EMQX_BAR__UNION_WITH_DEFAULT__VAL", "111"}
+           , {"EMQX_bar__field1", ""}
+           , {"EMQX_BAR__UNKNOWNx", "x"}
+           , {"EMQX_UNKNOWNx", "x"}
+           , {"EMQX___", "x"}
+           ])),
+    Unknown =
+        iolist_to_binary(
+          io_lib:format("~p", [lists:sort(["EMQX___",
+                                           "EMQX_UNKNOWNx",
+                                           "EMQX_BAR__UNKNOWNx"])])),
     receive
         {Ref, Level, Msg} ->
             ?assertEqual(warning, Level),
-            ?assertEqual(<<"unknown_environment_variable_discarded: EMQX_BAR__UNKNOWNx">>, Msg)
+            io:format(user, "expected: ~p", [Unknown]),
+            io:format(user, "     got: ~p", [Msg]),
+            ?assertEqual(<<"unknown_env_vars: ", Unknown/binary>>, Msg)
     end.
-
-check(Str) -> check(Str, #{format => richmap}).
 
 check(Str, Opts) ->
     {ok, RichMap} = hocon:binary(Str, Opts),
-    RichMap2 = hocon_schema:check(?MODULE, RichMap, Opts),
+    RichMap2 = hocon_schema:check(?MODULE, RichMap, Opts#{apply_override_envs => true}),
     hocon_schema:richmap_to_map(RichMap2).
 
 check_plain(Str) ->
@@ -252,7 +261,8 @@ richmap_to_map_test_() ->
 env_test_() ->
     F = fun (Str, Envs) ->
                     {ok, M} = hocon:binary(Str, #{format => richmap}),
-                    {Mapped, _} = with_envs(fun hocon_schema:map/2, [demo_schema, M],
+                    Opts = #{apply_override_envs => true},
+                    {Mapped, _} = with_envs(fun hocon_schema:map/4, [demo_schema, M, all, Opts],
                                             Envs ++ [{"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"}]),
                     Mapped
         end,
@@ -275,7 +285,7 @@ env_object_val_test() ->
     Conf = "root = {val = {f1 = 43}}",
     {ok, PlainMap} = hocon:binary(Conf, #{}),
     ?assertEqual(#{<<"root">> => #{<<"val">> => #{<<"f1">> => 42}}},
-        with_envs(fun hocon_schema:check_plain/2, [Sc, PlainMap],
+        with_envs(fun hocon_schema:check_plain/3, [Sc, PlainMap, #{apply_override_envs => true}],
             [ {"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"}
             , {"EMQX_ROOT__VAL", "{f1:42}"}
             ])).
@@ -285,17 +295,23 @@ env_array_val_test() ->
     Conf = "val = [a,b]",
     {ok, PlainMap} = hocon:binary(Conf, #{}),
     ?assertEqual(#{<<"val">> => ["c", "d"]},
-        with_envs(fun hocon_schema:check_plain/2, [Sc, PlainMap],
-            [ {"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"}
-            , {"EMQX_VAL", "[c, d]"}
-            ])).
+        with_envs(fun hocon_schema:check_plain/3, [Sc, PlainMap, #{apply_override_envs => true}],
+                  envs([{"EMQX_VAL", "[c, d]"}, {"EMQX___", "discard"}]))).
+
+env_map_val_test() ->
+    Sc = #{roots => [{"val", hoconsc:map(key, string())}]},
+    Conf = "val = {key = value}",
+    {ok, Map} = hocon:binary(Conf, #{format => map}),
+    ?assertEqual(#{<<"val">> => #{<<"key">> => "value2"}},
+        with_envs(fun hocon_schema:check_plain/3, [Sc, Map, #{apply_override_envs => true}],
+                  envs([{"EMQX_VAL__KEY", "value2"}]))).
 
 env_ip_port_test() ->
     Sc = #{roots => [{"val", string()}]},
     Conf = "val = \"127.0.0.1:1990\"",
     {ok, PlainMap} = hocon:binary(Conf, #{}),
     ?assertEqual(#{<<"val">> => "192.168.0.1:1991"},
-        with_envs(fun hocon_schema:check_plain/2, [Sc, PlainMap],
+        with_envs(fun hocon_schema:check_plain/3, [Sc, PlainMap, #{apply_override_envs => true}],
             [ {"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"}
             , {"EMQX_VAL", "192.168.0.1:1991"}
             ])).
@@ -340,6 +356,13 @@ real_enum_test() ->
     ?VALIDATION_ERR(#{reason := unable_to_convert_to_enum_symbol,
                       value := {"badvalue"}},
                     hocon_schema:check_plain(Sc, #{<<"val">> => {"badvalue"}})).
+bad_array_index_test() ->
+    Sc = #{roots => [{val, hoconsc:array(integer())}]},
+    Conf = "val = {first = 1}",
+    {ok, PlainMap} = hocon:binary(Conf, #{}),
+    ?assertThrow({_, [{validation_error, #{bad_array_index_keys := [<<"first">>],
+                                           path := "val"}}]},
+                 hocon_schema:check_plain(Sc, PlainMap)).
 
 array_of_enum_test() ->
     Sc = #{roots => [{val, hoconsc:array(hoconsc:enum([a, b, c]))}]},
@@ -584,7 +607,9 @@ sensitive_data_obfuscation_test() ->
     with_envs(
       fun() ->
               hocon_schema:check_plain(Sc, #{<<"secret">> => "aaa"},
-                                       #{logger => fun(_Level, Msg) -> Self ! Msg end}),
+                                       #{logger => fun(_Level, Msg) -> Self ! Msg end,
+                                         apply_override_envs => true
+                                        }),
               receive
                   #{hocon_env_var_name := "OBFUSCATION_TEST", path := Path, value := Value} ->
                       ?assertEqual("secret", Path),
@@ -768,7 +793,7 @@ test_array_env_override(Format) ->
         fun() ->
                 Conf = "",
                 {ok, Parsed} = hocon:binary(Conf, #{format => Format}),
-                Opts = #{format => Format, nullable => true},
+                Opts = #{format => Format, nullable => true, apply_override_envs => true},
                 ?assertEqual(#{<<"foo">> => [#{<<"kling">> => 111},
                                              #{<<"klang">> => 222}
                                             ]},
@@ -777,6 +802,18 @@ test_array_env_override(Format) ->
               {"EMQX_FOO__1__KLING", "111"},
               {"EMQX_FOO__2__KLANG", "222"}
              ]).
+
+array_env_override_ignore_test() ->
+    Sc = #{roots => [{foo, hoconsc:array(hoconsc:ref(foo))}],
+           fields => #{foo => [ {"intf", hoconsc:mk(integer())}]}
+          },
+    with_envs(
+        fun() ->
+                Conf = "",
+                {ok, Parsed} = hocon:binary(Conf, #{format => map}),
+                Opts = #{format => map, nullable => true, apply_override_envs => true},
+                ?assertEqual(#{}, hocon_schema:check(Sc, Parsed, Opts))
+        end, envs([{"EMQX_FOO__first__intf", "111"}])).
 
 bad_indexed_map_test() ->
     Sc = #{roots => [foo],
@@ -802,7 +839,8 @@ fill_defaults_with_env_override_test() ->
       fun() ->
               Conf0 = "foo={bar=121}",
               {ok, Conf} = hocon:binary(Conf0),
-              Res = hocon_schema:check_plain(Sc, Conf, #{only_fill_defaults => true}),
+              Res = hocon_schema:check_plain(Sc, Conf, #{only_fill_defaults => true,
+                                                         apply_override_envs => true}),
               ?assertEqual(#{<<"foo">> => #{<<"bar">> => 122}}, Res)
       end, envs([{"EMQX_FOO__BAR", "122"}])).
 
@@ -823,21 +861,6 @@ array_env_override_test_() ->
                Envs = EnvsFooBar13 ++ [{"EMQX_FOO__BAR__10", "10"}],
                ?assertError({bad_array_index, "EMQX_FOO__BAR__10"},
                              test_array_override(Sc, map, Envs))
-       end}
-    , {"bad_index",
-       fun() ->
-               Envs = envs([{"EMQX_FOO__BAR__not_index", "1"}]),
-               Throw = test_array_override(Sc, richmap, Envs),
-               ?assertMatch([{validation_error,
-                              #{bad_array_index_keys := [<<"not_index">>]}}], Throw)
-       end}
-    , {"bad_index-2",
-       fun() ->
-               Conf = <<"foo : {bar : [0, 2, 0]}">>,
-               Envs = envs([{"EMQX_FOO__BAR__x", "1"}]),
-               Throw = test_array_override(Sc, map, Envs, Conf),
-               ?assertMatch([{validation_error,
-                              #{bad_array_index_keys := [<<"x">>]}}], Throw)
        end}
     , {"bad_indexed_map",
        fun() ->
@@ -890,7 +913,8 @@ test_array_override(Sc, Format, Envs) ->
 test_array_override(Sc, Format, Envs, Conf) ->
     with_envs(fun() ->
                       {ok, Parsed} = hocon:binary(Conf, #{format => Format}),
-                      Opts = #{format => Format, nullable => true},
+                      Opts = #{format => Format, nullable => true,
+                               apply_override_envs => true},
                       try hocon_schema:check(Sc, Parsed, Opts)
                       catch throw : {_Sc, R} -> R
                       end
@@ -900,7 +924,7 @@ test_array_env_override_t2(Sc, Format) ->
     with_envs(
         fun() ->
                 {ok, Parsed} = hocon:binary(<<>>, #{format => Format}),
-                Opts = #{format => Format, nullable => true},
+                Opts = #{format => Format, nullable => true, apply_override_envs => true},
                 ?assertEqual(#{<<"foo">> => #{<<"bar">> => [2, 1],
                                               <<"quu">> => ["quu"]}},
                              hocon_schema:richmap_to_map(hocon_schema:check(Sc, Parsed, Opts)))
@@ -925,8 +949,9 @@ ref_nullable_test() ->
     ?assertEqual(#{<<"x">> => "y"}, hocon_schema:check_plain(Sc, Map)),
     with_envs(
       fun() ->
+            Opts = #{apply_override_envs => true},
             {ok, Map2} = hocon:binary("k = {a: a, b: b}, x = y", #{format => map}),
-            ?assertEqual(#{<<"x">> => "y"}, hocon_schema:check_plain(Sc, Map2))
+            ?assertEqual(#{<<"x">> => "y"}, hocon_schema:check_plain(Sc, Map2, Opts))
       end, [{"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"},
             {"EMQX_K", "null"}
            ]).
@@ -964,7 +989,7 @@ lazy_root_env_override_test() ->
       fun() ->
               Conf = "foo = {kling = 1}",
               {ok, PlainMap} = hocon:binary(Conf, #{}),
-              Opts = #{format => map, nullable => true},
+              Opts = #{format => map, nullable => true, apply_override_envs => true},
               ?assertEqual(#{<<"foo">> => #{<<"kling">> => 1}},
                            hocon_schema:check(Sc, PlainMap, Opts)),
               ?assertEqual(#{<<"foo">> => #{<<"kling">> => 111,
@@ -1045,7 +1070,7 @@ override_env_with_include_test() ->
       fun() ->
               Conf = "foo = {kling = 1}",
               {ok, PlainMap} = hocon:binary(Conf, #{}),
-              Opts = #{format => map, nullable => true},
+              Opts = #{format => map, nullable => true, apply_override_envs => true},
               ?assertEqual(#{<<"foo">> => #{<<"kling">> => 1,
                                             <<"klang">> => 233}},
                            hocon_schema:check(Sc, PlainMap, Opts#{check_lazy => true}))
@@ -1067,11 +1092,12 @@ override_env_with_include_abs_path_test() ->
     with_envs(
       fun() ->
               Conf = "foo = {kling = 1}",
-              {ok, PlainMap} = hocon:binary(Conf, #{}),
-              Opts = #{format => map, nullable => true},
+              {ok, PlainMap} = hocon:binary(Conf, #{apply_override_envs => true}),
+              Opts = #{format => map, nullable => true, apply_override_envs => true},
               ?assertEqual(#{<<"foo">> => #{<<"kling">> => 123,
                                             <<"klang">> => 456}},
-                           hocon_schema:check(Sc, PlainMap, Opts#{check_lazy => true}))
+                           hocon_schema:check(Sc, PlainMap, Opts#{check_lazy => true,
+                                                                  apply_override_envs => true}))
       end, [{"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"},
             {"EMQX_FOO", "{include \""++ Include ++ "\"}"}
            ]).
@@ -1112,3 +1138,4 @@ redundant_field_test() ->
     ?assertThrow({_, [{validation_error, #{reason := {invalid_id, <<"a:c">>}}}]},
                  hocon_schema:check(Sc, Conf3Map, Opts)),
     ok.
+


### PR DESCRIPTION
1. Made `apply_override_envs` default to `false`, since `false` is more commonly used than `true`
1. Added `hocon_schema:merge_env_overrides/4` so we can merge base + overrides without type checks.
1. Removed per-field customisable env variable name (since it's not possible to to apply without type check, i.e contradicting [1]).
1. Support array element override from HOCON values.
  Prior to this, `a=[], a.1=1`
  is parsed to `#{<<"a">> => #{<<"1">> => 1}}`,
  now it's `#{<<"a">> => [1]}`.
  This behaviour is consistent to: `a=[]` with env override `export EMQX_A__1=1`