### PR TITLE
Refactor: split hocon_schema module

### DIFF
--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -143,8 +143,8 @@ translation("foo") ->
   [{"range", fun range/1}].
 
 range(Conf) ->
-    Min = hocon_schema:deep_get("foo.min", Conf, value),
-    Max = hocon_schema:deep_get("foo.max", Conf, value),
+    Min = hocon_maps:get("foo.min", Conf),
+    Max = hocon_maps:get("foo.max", Conf),
     case Min < Max of
         true ->
             {Min, Max};
@@ -154,7 +154,7 @@ range(Conf) ->
 ```
 
 As in the example, a translation callback is provided with the global config,
-specific field values can be retrieved with `hocon_schema:deep_get` API.
+specific field values can be retrieved with `hocon_maps:get` API.
 
 ### Config integrity validation
 
@@ -174,8 +174,8 @@ validations() ->
   [{"min =< max", fun min_max/1}].
 
 min_max(Conf) ->
-    Min = hocon_schema:deep_get("foo.min", Conf, value),
-    Max = hocon_schema:deep_get("foo.max", Conf, value),
+    Min = hocon_maps:get("foo.min", Conf),
+    Max = hocon_maps:get("foo.max", Conf),
     case Min =< Max of
         true -> ok %% return true | ok to pass this validation
         false -> "min > max is not allowed"

--- a/sample-schemas/demo_schema.erl
+++ b/sample-schemas/demo_schema.erl
@@ -82,8 +82,8 @@ setting(type) -> string();
 setting(_) -> undefined.
 
 range(Conf) ->
-    Min = hocon_schema:get_value("foo.min", Conf),
-    Max = hocon_schema:get_value("foo.max", Conf),
+    Min = hocon_maps:get("foo.min", Conf),
+    Max = hocon_maps:get("foo.max", Conf),
     case Min < Max of
         true ->
             {Min, Max};

--- a/sample-schemas/emqx_schema.erl
+++ b/sample-schemas/emqx_schema.erl
@@ -1015,7 +1015,7 @@ map_zones(Opt, Val) ->
 
 -spec(conf_get(string() | [string()], hocon:config()) -> term()).
 conf_get(Key, Conf) ->
-    V = hocon_schema:get_value(Key, Conf),
+    V = hocon_maps:get(Key, Conf),
     case is_binary(V) of
         true ->
             binary_to_list(V);
@@ -1024,7 +1024,7 @@ conf_get(Key, Conf) ->
     end.
 
 conf_get(Key, Conf, Default) ->
-    V = hocon_schema:get_value(Key, Conf, Default),
+    V = hocon_maps:get(Key, Conf, Default),
     case is_binary(V) of
         true ->
             binary_to_list(V);

--- a/src/hocon.erl
+++ b/src/hocon.erl
@@ -344,7 +344,7 @@ do_concat([{#{?HOCON_T := key}=K, Value} | More], Metadata, Acc) ->
 do_concat([Other | More], Metadata, Acc) ->
     do_concat(More, Metadata, [Other | Acc]).
 
--spec(transform(hocon_token:boxed(), map()) -> hocon:config()).
+-spec(transform(hocon_token:boxed(), map()) -> config()).
 transform(#{?HOCON_T := object, ?HOCON_V := V} = O, #{format := richmap} = Opts) ->
     NewV = do_transform(remove_nothing(V), #{}, Opts),
     O#{?HOCON_V => NewV};

--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -144,8 +144,8 @@ get(ParsedArgs, [Query | _]) ->
     RootName = hocon_schema:resolve_struct_name(Schema, RootName0),
     %% do not log anything for `get` commands
     Opts = #{logger => fun(_, _) -> ok end, apply_override_envs => true},
-    {_, NewConf} = hocon_schema:map(Schema, Conf, [RootName], Opts),
-    ?STDOUT("~0p", [hocon_schema:get_value(Query, NewConf)]),
+    {_, NewConf} = hocon_tconf:map(Schema, Conf, [RootName], Opts),
+    ?STDOUT("~0p", [hocon_maps:get(Query, NewConf)]),
     stop_ok().
 
 pretty_print(ParsedArgs) ->
@@ -252,7 +252,7 @@ generate(ParsedArgs) ->
                  false -> fun(_, _) -> ok end
              end,
     Opts = #{logger => LogFun, apply_override_envs => true},
-    try hocon_schema:generate(Schema, Conf, Opts) of
+    try hocon_tconf:generate(Schema, Conf, Opts) of
         NewConfig ->
             AppConfig = proplists:delete(vm_args, NewConfig),
             VmArgs = stringify(proplists:get_value(vm_args, NewConfig)),

--- a/src/hocon_maps.erl
+++ b/src/hocon_maps.erl
@@ -1,0 +1,148 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(hocon_maps).
+
+%% Deep ops of deep maps.
+-export([deep_get/2, deep_put/4]).
+
+%% Access maybe-rich map values,
+%% Always reutrn plain value.
+-export([get/2, get/3]).
+
+-export([do_put/4]). %% internal
+
+-include("hocon_private.hrl").
+
+-define(EMPTY_MAP, #{}).
+
+%% this can be the opts() from hocon_tconf, but only `atom_key' is relevant
+-type opts() :: #{atom_key => boolean(),
+                  _ => _}.
+
+%% @doc put unboxed value to the richmap box
+%% this function is called places where there is no boxing context
+%% so it has to accept unboxed value.
+-spec deep_put(string(), term(), hocon:config(), opts()) -> hocon:config().
+deep_put(Path, Value, Conf, Opts) ->
+    put_rich(Opts, hocon_util:split_path(Path), Value, Conf).
+
+put_rich(_Opts, [], Value, Box) ->
+    boxit(Value, Box);
+put_rich(Opts, [Name | Path], Value, Box) ->
+    V0 = safe_unbox(Box),
+    GoDeep = fun(Elem) -> put_rich(Opts, Path, Value, Elem) end,
+    V = do_put(V0, Name, GoDeep, Opts),
+    boxit(V, Box).
+
+do_put(V, Name, GoDeep, Opts) ->
+    case maybe_array(V) andalso hocon_util:is_array_index(Name) of
+        {true, Index} -> update_array_element(V, Index, GoDeep);
+        false when is_map(V) -> update_map_field(Opts, V, Name, GoDeep);
+        false -> update_map_field(Opts, #{}, Name, GoDeep)
+    end.
+
+maybe_array(V) when is_list(V) -> true;
+maybe_array(V) -> V =:= ?EMPTY_MAP.
+
+update_array_element(?EMPTY_MAP, Index, GoDeep) ->
+    update_array_element([], Index, GoDeep);
+update_array_element(List, Index, GoDeep) when is_list(List) ->
+    hocon_util:update_array_element(List, Index, GoDeep).
+
+update_map_field(Opts, Map, FieldName, GoDeep) ->
+    FieldV0 = maps:get(FieldName, Map, ?EMPTY_MAP),
+    FieldV = GoDeep(FieldV0),
+    Map1 = maps:without([FieldName], Map),
+    Map1#{maybe_atom(Opts, FieldName) => FieldV}.
+
+maybe_atom(#{atom_key := true}, Name) when is_binary(Name) ->
+    try
+        binary_to_existing_atom(Name, utf8)
+    catch
+        _ : _ ->
+            error({non_existing_atom, Name})
+    end;
+maybe_atom(_Opts, Name) ->
+    Name.
+
+safe_unbox(MaybeBox) ->
+    case maps:get(?HOCON_V, MaybeBox, undefined) of
+        undefined -> ?EMPTY_MAP;
+        Value -> Value
+    end.
+
+boxit(Value, Box) -> Box#{?HOCON_V => Value}.
+
+%% @doc Get value from a plain or rich map.
+%% `undefined' is returned if no such value path.
+%% NOTE: always return plain-value.
+-spec get(string(), hocon:config(), term()) -> term().
+get(Path, Config, Default) ->
+    case get(Path, Config) of
+        undefined -> Default;
+        V -> V
+    end.
+
+%% @doc get a child node from richmap, return value also a richmap.
+%% `undefined' is returned if no value path.
+%% Key (first arg) can be "foo.bar.baz" or ["foo.bar", "baz"] or ["foo", "bar", "baz"].
+-spec deep_get(string() | [string()], hocon:config()) -> hocon:config() | undefined.
+deep_get(Path, Conf) ->
+    do_get(hocon_util:split_path(Path), Conf, richmap).
+
+%% @doc Get value from a maybe-rich map.
+%% always return plain-value.
+-spec get(string(), hocon:config()) -> term().
+get(Path, Map) ->
+    case hocon_util:is_richmap(Map) of
+        true ->
+            C = deep_get(Path, Map),
+            hocon_util:richmap_to_map(C);
+        false ->
+            do_get(hocon_util:split_path(Path), Map, map)
+    end.
+
+do_get([], Conf, _Format) -> Conf;
+do_get([H | T], Conf, Format) ->
+    FieldV = try_get(H, Conf, Format),
+    do_get(T, FieldV, Format).
+
+try_get(_Key, undefined, _Format) ->
+    undefined;
+try_get(Key, Conf, richmap) ->
+    #{?HOCON_V := V} = Conf,
+    try_get(Key, V, map);
+try_get(Key, Conf, map) when is_map(Conf) ->
+    case maps:get(Key, Conf, undefined) of
+        undefined ->
+            try binary_to_existing_atom(Key, utf8) of
+                AtomKey -> maps:get(AtomKey, Conf, undefined)
+            catch
+                error : badarg ->
+                    undefined
+            end;
+        Value ->
+            Value
+    end;
+try_get(Key, Conf, map) when is_list(Conf) ->
+    try binary_to_integer(Key) of
+        N ->
+            lists:nth(N, Conf)
+    catch
+        error : badarg ->
+            undefined
+    end.

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -1,0 +1,307 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(hocon_schema).
+
+%% behaviour APIs
+-export([ roots/1
+        , fields/2
+        , fields_and_meta/2
+        , translations/1
+        , translation/2
+        , validations/1
+        ]).
+
+-export([ find_structs/1
+        , override/2
+        , namespace/1
+        , resolve_struct_name/2
+        , root_names/1
+        , field_schema/2
+        ]).
+
+-export_type([ field_schema/0
+             , name/0
+             , schema/0
+             , typefunc/0
+             , translationfunc/0
+             ]).
+
+-callback namespace() -> name().
+-callback roots() -> [root_type()].
+-callback fields(name()) -> fields().
+-callback translations() -> [name()].
+-callback translation(name()) -> [translation()].
+-callback validations() -> [validation()].
+
+-optional_callbacks([ namespace/0
+                    , roots/0
+                    , fields/1
+                    , translations/0
+                    , translation/1
+                    , validations/0
+                    ]).
+
+-include("hoconsc.hrl").
+-include("hocon_private.hrl").
+
+-type name() :: atom() | string() | binary().
+-type type() :: typerefl:type() %% primitive (or complex, but terminal) type
+              | name() %% reference to another struct
+              | ?ARRAY(type()) %% array of
+              | ?UNION([type()]) %% one-of
+              | ?ENUM([atom()]) %% one-of atoms, data is allowed to be binary()
+              .
+
+-type field_schema() :: typerefl:type()
+                      | ?UNION([type()])
+                      | ?ARRAY(type())
+                      | ?ENUM(type())
+                      | field_schema_map()
+                      | field_schema_fun().
+-type field_schema_fun() :: fun((_) -> _).
+-type field_schema_map() ::
+        #{ type := type()
+         , default => term()
+         , mapping => undefined | string()
+         , converter => undefined | translationfunc()
+         , validator => undefined | validationfun()
+           %% set true if a field is allowed to be `undefined`
+           %% NOTE: has no point setting it to `true` if field has a default value
+         , nullable => true | false | {true, recursively} % default = true
+           %% for sensitive data obfuscation (password, token)
+         , sensitive => boolean()
+         , desc => iodata()
+         , hidden => boolean() %% hide it from doc generation
+         }.
+
+-type field() :: {name(), typefunc() | field_schema()}.
+-type fields() :: [field()] | #{fields := [field()],
+                                desc => iodata()
+                               }.
+-type validation() :: {name(), validationfun()}.
+-type root_type() :: name() | field().
+-type schema() :: module()
+                | #{ roots := [root_type()]
+                   , fields := #{name() => fields()} | fun((name()) -> fields())
+                   , translations => #{name() => [translation()]} %% for config mappings
+                   , validations => [validation()] %% for config integrity checks
+                   , namespace => atom()
+                   }.
+
+-type translation() :: {name(), translationfunc()}.
+-type typefunc() :: fun((_) -> _).
+-type translationfunc() :: fun((hocon:config()) -> hocon:config()).
+-type validationfun() :: fun((hocon:config()) -> ok | boolean() | {error, term()}).
+-type bin_name() :: binary().
+
+%% @doc Get translation identified by `Name' from the given schema.
+-spec translation(schema(), name()) -> [translation()].
+translation(Mod, Name) when is_atom(Mod) -> Mod:translation(Name);
+translation(#{translations := Trs}, Name) -> maps:get(Name, Trs).
+
+%% @doc Get all translations from the given schema.
+-spec translations(schema()) -> [name()].
+translations(Mod) when is_atom(Mod) ->
+    case erlang:function_exported(Mod, translations, 0) of
+        false -> [];
+        true -> Mod:translations()
+    end;
+translations(#{translations := Trs}) -> maps:keys(Trs);
+translations(Sc) when is_map(Sc) -> [].
+
+%% @doc Get all validations from the given schema.
+-spec validations(schema()) -> [validation()].
+validations(Mod) when is_atom(Mod) ->
+    case erlang:function_exported(Mod, validations, 0) of
+        false -> [];
+        true -> Mod:validations()
+    end;
+validations(Sc) -> maps:get(validations, Sc, []).
+
+%% @doc Make a higher order schema by overriding `Base' with `OnTop'
+-spec override(field_schema(), field_schema_map()) -> field_schema_fun().
+override(Base, OnTop) ->
+    fun(SchemaKey) ->
+            case maps:is_key(SchemaKey, OnTop) of
+                true -> field_schema(OnTop, SchemaKey);
+                false -> field_schema(Base, SchemaKey)
+            end
+    end.
+
+%% @doc Get namespace of a schema.
+-spec namespace(schema()) -> undefined | binary().
+namespace(Schema) ->
+    case is_atom(Schema) of
+        true ->
+            case erlang:function_exported(Schema, namespace, 0) of
+                true  -> Schema:namespace();
+                false -> undefined
+            end;
+        false ->
+            maps:get(namespace, Schema, undefined)
+    end.
+
+%% @doc Resolve struct name from a guess.
+resolve_struct_name(Schema, StructName) ->
+    case lists:keyfind(bin(StructName), 1, roots(Schema)) of
+        {_, {N, _Sc}} -> N;
+        false -> throw({unknown_struct_name, Schema, StructName})
+    end.
+
+%% @doc Get all root names from a schema.
+-spec root_names(schema()) -> [binary()].
+root_names(Schema) -> [Name || {Name, _} <- roots(Schema)].
+
+%% @doc Get exported root fields in format [{BinaryName, {OriginalName, FieldSchema}}].
+-spec roots(schema()) -> [{bin_name(), {name(), field_schema()}}].
+roots(Schema) ->
+    All =
+      lists:map(fun({N, T}) -> {bin(N), {N, T}};
+                   (N) when is_atom(Schema) -> {bin(N), {N, ?R_REF(Schema, N)}};
+                   (N) -> {bin(N), {N, ?REF(N)}}
+                end, do_roots(Schema)),
+    AllNames = [Name || {Name, _} <- All],
+    UniqueNames = lists:usort(AllNames),
+    case length(UniqueNames) =:= length(AllNames) of
+        true  ->
+            All;
+        false ->
+            error({duplicated_root_names, AllNames -- UniqueNames})
+    end.
+
+do_roots(Mod) when is_atom(Mod) -> Mod:roots();
+do_roots(#{roots := Names}) -> Names.
+
+%% @doc Get fields of the struct for the given struct name.
+-spec fields(schema(), name()) -> [field()].
+fields(Sc, Name) ->
+    #{fields := Fields} = fields_and_meta(Sc, Name),
+    Fields.
+
+%% @doc Get fields and meta data of the struct for the given struct name.
+-spec fields_and_meta(schema(), name()) -> fields().
+fields_and_meta(Mod, Name) when is_atom(Mod) ->
+    ensure_struct_meta(Mod:fields(Name));
+fields_and_meta(#{fields := Fields}, Name) when is_function(Fields) ->
+    ensure_struct_meta(Fields(Name));
+fields_and_meta(#{fields := Fields}, Name) when is_map(Fields) ->
+    ensure_struct_meta(maps:get(Name, Fields)).
+
+ensure_struct_meta(Fields) when is_list(Fields) -> #{fields => Fields};
+ensure_struct_meta(#{fields := _} = Fields) -> Fields.
+
+find_structs(Schema, Fields) ->
+    find_structs(Schema, Fields, #{}, _ValueStack = [], _TypeStack = []).
+
+find_structs(Schema, #{fields := Fields}, Acc, Stack, TStack) ->
+    find_structs(Schema, Fields, Acc, Stack, TStack);
+find_structs(_Schema, [], Acc, _Stack, _TStack) -> Acc;
+find_structs(Schema, [{FieldName, FieldSchema} | Fields], Acc0, Stack, TStack) ->
+    Type = field_schema(FieldSchema, type),
+    Acc = find_structs_per_type(Schema, Type, Acc0, [str(FieldName) | Stack], TStack),
+    find_structs(Schema, Fields, Acc, Stack, TStack).
+
+find_structs_per_type(Schema, Name, Acc, Stack, TStack) when is_list(Name) ->
+    find_ref(Schema, Name, Acc, Stack, TStack);
+find_structs_per_type(Schema, ?REF(Name), Acc, Stack, TStack) ->
+    find_ref(Schema, Name, Acc, Stack, TStack);
+find_structs_per_type(_Schema, ?R_REF(Module, Name), Acc, Stack, TStack) ->
+    find_ref(Module, Name, Acc, Stack, TStack);
+find_structs_per_type(Schema, ?LAZY(Type), Acc, Stack, TStack) ->
+    find_structs_per_type(Schema, Type, Acc, Stack, TStack);
+find_structs_per_type(Schema, ?ARRAY(Type), Acc, Stack, TStack) ->
+    find_structs_per_type(Schema, Type, Acc, ["$INDEX" | Stack], TStack);
+find_structs_per_type(Schema, ?UNION(Types), Acc, Stack, TStack) ->
+    lists:foldl(fun(T, AccIn) ->
+                        find_structs_per_type(Schema, T, AccIn, Stack, TStack)
+                end, Acc, Types);
+find_structs_per_type(Schema, ?MAP(Name, Type), Acc, Stack, TStack) ->
+    find_structs_per_type(Schema, Type, Acc, ["$" ++ str(Name) | Stack], TStack);
+find_structs_per_type(_Schema, _Type, Acc, _Stack, _TStack) ->
+    Acc.
+
+find_ref(Schema, Name, Acc, Stack, TStack) ->
+    Namespace = hocon_schema:namespace(Schema),
+    Key = {Namespace, Name},
+    Path = path(Stack),
+    Paths =
+        case maps:find(Key, Acc) of
+            {ok, #{paths := Ps}} -> Ps;
+            error -> #{}
+        end,
+    case lists:member(Key, TStack) of
+        true ->
+            %% loop reference, break here, otherwise never exit
+            Acc;
+        false ->
+            Fields0 = fields_and_meta(Schema, Name),
+            Fields = Fields0#{paths => Paths#{Path => true}},
+            find_structs(Schema, Fields, Acc#{Key => Fields}, Stack, [Key | TStack])
+    end.
+
+%% @doc Collect all structs defined in the given schema.
+-spec find_structs(schema()) ->
+        {RootNs :: name(), RootFields :: [field()],
+         [{Namespace :: name(), Name :: name(), fields()}]}.
+find_structs(Schema) ->
+    RootFields = unify_roots(Schema),
+    All = find_structs(Schema, RootFields),
+    RootNs = hocon_schema:namespace(Schema),
+    {RootNs, RootFields,
+     [{Ns, Name, Fields} || {{Ns, Name}, Fields} <- lists:keysort(1, maps:to_list(All))]}.
+
+unify_roots(Schema) ->
+    Roots = ?MODULE:roots(Schema),
+    lists:map(fun({_BinName, {RootFieldName, RootFieldSchema}}) ->
+                      {RootFieldName, RootFieldSchema}
+              end, Roots).
+
+str(A) when is_atom(A) -> atom_to_list(A);
+str(B) when is_binary(B) -> binary_to_list(B);
+str(S) when is_list(S) -> S.
+
+bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
+bin(S) -> iolist_to_binary(S).
+
+%% get type validation stack.
+path(Stack) when is_list(Stack) ->
+    string:join(lists:reverse(lists:map(fun str/1, Stack)), ".").
+
+field_schema(Atom, type) when is_atom(Atom) -> Atom;
+field_schema(Atom, _Other) when is_atom(Atom) -> undefined;
+field_schema(Type, SchemaKey) when ?IS_TYPEREFL(Type) ->
+    field_schema(hoconsc:mk(Type), SchemaKey);
+field_schema(?MAP(_Name, _Type) = Map, SchemaKey) ->
+    field_schema(hoconsc:mk(Map), SchemaKey);
+field_schema(?LAZY(_) = Lazy, SchemaKey) ->
+    field_schema(hoconsc:mk(Lazy), SchemaKey);
+field_schema(Ref, SchemaKey) when is_list(Ref) ->
+    field_schema(hoconsc:mk(Ref), SchemaKey);
+field_schema(?REF(_) = Ref, SchemaKey) ->
+    field_schema(hoconsc:mk(Ref), SchemaKey);
+field_schema(?R_REF(_, _) = Ref, SchemaKey) ->
+    field_schema(hoconsc:mk(Ref), SchemaKey);
+field_schema(?ARRAY(_) = Array, SchemaKey) ->
+    field_schema(hoconsc:mk(Array), SchemaKey);
+field_schema(?UNION(_) = Union, SchemaKey) ->
+    field_schema(hoconsc:mk(Union), SchemaKey);
+field_schema(?ENUM(_) = Enum, SchemaKey) ->
+    field_schema(hoconsc:mk(Enum), SchemaKey);
+field_schema(FieldSchema, SchemaKey) when is_function(FieldSchema, 1) ->
+    FieldSchema(SchemaKey);
+field_schema(FieldSchema, SchemaKey) when is_map(FieldSchema) ->
+    maps:get(SchemaKey, FieldSchema, undefined).

--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(hocon_schema).
+-module(hocon_tconf).
 
 -elvis([{elvis_style, god_modules, disable}]).
 

--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -18,95 +18,20 @@
 
 -elvis([{elvis_style, god_modules, disable}]).
 
-%% behaviour APIs
--export([ roots/1
-        , fields/2
-        , fields_and_meta/2
-        , translations/1
-        , translation/2
-        , validations/1
-        ]).
-
 %% data validation and transformation
 -export([map/2, map/3, map/4]).
 -export([translate/3]).
 -export([generate/2, generate/3, map_translate/3]).
 -export([check/2, check/3, check_plain/2, check_plain/3, check_plain/4]).
 -export([merge_env_overrides/4]).
--export([richmap_to_map/1, get_value/2, get_value/3]).
-
-%% schema access
--export([namespace/1, resolve_struct_name/2, root_names/1]).
--export([field_schema/2, override/2]).
-
--export([find_structs/1]). %% internal use
+-export([nest/1]).
 
 -include("hoconsc.hrl").
 -include("hocon_private.hrl").
 
--ifdef(TEST).
--export([deep_get/2, deep_put/4]).
--export([nest/1]).
--endif.
-
--export_type([ field_schema/0
-             , name/0
-             , opts/0
-             , schema/0
-             , typefunc/0
-             , translationfunc/0
-             ]).
-
--type name() :: atom() | string() | binary().
--type type() :: typerefl:type() %% primitive (or complex, but terminal) type
-              | name() %% reference to another struct
-              | ?ARRAY(type()) %% array of
-              | ?UNION([type()]) %% one-of
-              | ?ENUM([atom()]) %% one-of atoms, data is allowed to be binary()
-              .
-
--type typefunc() :: fun((_) -> _).
--type translationfunc() :: fun((hocon:config()) -> hocon:config()).
--type validationfun() :: fun((hocon:config()) -> ok | boolean() | {error, term()}).
--type field_schema() :: typerefl:type()
-                      | ?UNION([type()])
-                      | ?ARRAY(type())
-                      | ?ENUM(type())
-                      | field_schema_map()
-                      | field_schema_fun().
--type field_schema_fun() :: fun((_) -> _).
--type field_schema_map() ::
-        #{ type := type()
-         , default => term()
-         , mapping => undefined | string()
-         , converter => undefined | translationfunc()
-         , validator => undefined | validationfun()
-           %% set true if a field is allowed to be `undefined`
-           %% NOTE: has no point setting it to `true` if field has a default value
-         , nullable => true | false | {true, recursively} % default = true
-           %% for sensitive data obfuscation (password, token)
-         , sensitive => boolean()
-         , desc => iodata()
-         , hidden => boolean() %% hide it from doc generation
-         }.
-
--type field() :: {name(), typefunc() | field_schema()}.
--type fields() :: [field()] | #{fields := [field()],
-                                desc => iodata()
-                               }.
--type translation() :: {name(), translationfunc()}.
--type validation() :: {name(), validationfun()}.
--type root_type() :: name() | field().
--type schema() :: module()
-                | #{ roots := [root_type()]
-                   , fields := #{name() => fields()} | fun((name()) -> fields())
-                   , translations => #{name() => [translation()]} %% for config mappings
-                   , validations => [validation()] %% for config integrity checks
-                   , namespace => atom()
-                   }.
+-export_type([opts/0]).
 
 -define(FROM_ENV_VAR(Name, Value), {'$FROM_ENV_VAR', Name, Value}).
--define(IS_NON_EMPTY_STRING(X), (is_list(X) andalso X =/= [] andalso is_integer(hd(X)))).
 -type loggerfunc() :: fun((atom(), map()) -> ok).
 %% Config map/check options.
 -type opts() :: #{ logger => loggerfunc()
@@ -133,21 +58,8 @@
                  , schema => schema()
                  , check_lazy => boolean()
                  }.
-
--callback namespace() -> name().
--callback roots() -> [root_type()].
--callback fields(name()) -> fields().
--callback translations() -> [name()].
--callback translation(name()) -> [translation()].
--callback validations() -> [validation()].
-
--optional_callbacks([ namespace/0
-                    , roots/0
-                    , fields/1
-                    , translations/0
-                    , translation/1
-                    , validations/0
-                    ]).
+-type name() :: hocon_schema:name().
+-type schema() :: hocon_schema:schema().
 
 -define(ERR(Code, Context), {Code, Context}).
 -define(ERRS(Code, Context), [?ERR(Code, Context)]).
@@ -156,121 +68,10 @@
 
 -define(DEFAULT_NULLABLE, true).
 
--define(EMPTY_MAP, #{}).
 -define(META_BOX(Tag, Metadata), #{?METADATA => #{Tag => Metadata}}).
 -define(NULL_BOX, #{?METADATA => #{made_for => null_value}}).
 -define(MAGIC, '$magic_chicken').
 -define(MAGIC_SCHEMA, #{type => ?MAGIC}).
-
-%% @doc Make a higher order schema by overriding `Base' with `OnTop'
--spec override(field_schema(), field_schema_map()) -> field_schema_fun().
-override(Base, OnTop) ->
-    fun(SchemaKey) ->
-            case maps:is_key(SchemaKey, OnTop) of
-                true -> field_schema(OnTop, SchemaKey);
-                false -> field_schema(Base, SchemaKey)
-            end
-    end.
-
-%% behaviour APIs
--spec roots(schema()) -> [{name(), {name(), field_schema()}}].
-roots(Schema) ->
-    All =
-      lists:map(fun({N, T}) -> {bin(N), {N, T}};
-                   (N) when is_atom(Schema) -> {bin(N), {N, ?R_REF(Schema, N)}};
-                   (N) -> {bin(N), {N, ?REF(N)}}
-                end, do_roots(Schema)),
-    AllNames = [Name || {Name, _} <- All],
-    UniqueNames = lists:usort(AllNames),
-    case length(UniqueNames) =:= length(AllNames) of
-        true  ->
-            All;
-        false ->
-            error({duplicated_root_names, AllNames -- UniqueNames})
-    end.
-
-%% @private Collect all structs defined in the given schema.
--spec find_structs(schema()) ->
-        {RootNs :: name(), RootFields :: [field()],
-         [{Namespace :: name(), Name :: name(), fields()}]}.
-find_structs(Schema) ->
-    RootFields = unify_roots(Schema),
-    All = find_structs(Schema, RootFields),
-    RootNs = hocon_schema:namespace(Schema),
-    {RootNs, RootFields,
-     [{Ns, Name, Fields} || {{Ns, Name}, Fields} <- lists:keysort(1, maps:to_list(All))]}.
-
-unify_roots(Schema) ->
-    Roots = ?MODULE:roots(Schema),
-    lists:map(fun({_BinName, {RootFieldName, RootFieldSchema}}) ->
-                      {RootFieldName, RootFieldSchema}
-              end, Roots).
-
-do_roots(Mod) when is_atom(Mod) -> Mod:roots();
-do_roots(#{roots := Names}) -> Names.
-
-%% @doc Get fields of the struct for the given struct name.
--spec fields(schema(), name()) -> [field()].
-fields(Sc, Name) ->
-    #{fields := Fields} = fields_and_meta(Sc, Name),
-    Fields.
-
-%% @doc Get fields and meta data of the struct for the given struct name.
--spec fields_and_meta(schema(), name()) -> fields().
-fields_and_meta(Mod, Name) when is_atom(Mod) ->
-    ensure_struct_meta(Mod:fields(Name));
-fields_and_meta(#{fields := Fields}, Name) when is_function(Fields) ->
-    ensure_struct_meta(Fields(Name));
-fields_and_meta(#{fields := Fields}, Name) when is_map(Fields) ->
-    ensure_struct_meta(maps:get(Name, Fields)).
-
-ensure_struct_meta(Fields) when is_list(Fields) -> #{fields => Fields};
-ensure_struct_meta(#{fields := _} = Fields) -> Fields.
-
--spec translations(schema()) -> [name()].
-translations(Mod) when is_atom(Mod) ->
-    case erlang:function_exported(Mod, translations, 0) of
-        false -> [];
-        true -> Mod:translations()
-    end;
-translations(#{translations := Trs}) -> maps:keys(Trs);
-translations(Sc) when is_map(Sc) -> [].
-
--spec translation(schema(), name()) -> [translation()].
-translation(Mod, Name) when is_atom(Mod) -> Mod:translation(Name);
-translation(#{translations := Trs}, Name) -> maps:get(Name, Trs).
-
--spec validations(schema()) -> [validation()].
-validations(Mod) when is_atom(Mod) ->
-    case erlang:function_exported(Mod, validations, 0) of
-        false -> [];
-        true -> Mod:validations()
-    end;
-validations(Sc) -> maps:get(validations, Sc, []).
-
-%% @doc Get namespace of a schema.
--spec namespace(schema()) -> undefined | binary().
-namespace(Schema) ->
-    case is_atom(Schema) of
-        true ->
-            case erlang:function_exported(Schema, namespace, 0) of
-                true  -> Schema:namespace();
-                false -> undefined
-            end;
-        false ->
-            maps:get(namespace, Schema, undefined)
-    end.
-
-%% @doc Resolve struct name from a guess.
-resolve_struct_name(Schema, StructName) ->
-    case lists:keyfind(bin(StructName), 1, roots(Schema)) of
-        {_, {N, _Sc}} -> N;
-        false -> throw({unknown_struct_name, Schema, StructName})
-    end.
-
-%% @doc Get all root names from a schema.
--spec root_names(schema()) -> [binary()].
-root_names(Schema) -> [Name || {Name, _} <- roots(Schema)].
 
 %% @doc generates application env from a parsed .conf and a schema module.
 %% For example, one can set the output values by
@@ -312,10 +113,11 @@ set_value([HeadToken | MoreTokens], PList, Value) ->
 
 -spec translate(schema(), hocon:config(), [proplists:property()]) -> [proplists:property()].
 translate(Schema, Conf, Mapped) ->
-    case translations(Schema) of
+    case hocon_schema:translations(Schema) of
         [] -> Mapped;
         Namespaces ->
-            Res = lists:append([do_translate(translation(Schema, N), str(N), Conf, Mapped) ||
+            Res = lists:append([do_translate(hocon_schema:translation(Schema, N),
+                                             str(N), Conf, Mapped) ||
                         N <- Namespaces]),
             ok = assert_no_error(Schema, Res),
             %% rm field if translation returns undefined
@@ -343,7 +145,7 @@ assert_integrity(Schema, Conf0, #{format := Format}) ->
                richmap -> richmap_to_map(Conf0);
                map -> Conf0
            end,
-    Names = validations(Schema),
+    Names = hocon_schema:validations(Schema),
     Errors = assert_integrity(Schema, Names, Conf, []),
     ok = assert_no_error(Schema, Errors).
 
@@ -413,7 +215,7 @@ maybe_convert_to_plain_map(Conf, _Opts) ->
 
 -spec map(schema(), hocon:config()) -> {[proplists:property()], hocon:config()}.
 map(Schema, Conf) ->
-    Roots = [N || {N, _} <- roots(Schema)],
+    Roots = [N || {N, _} <- hocon_schema:roots(Schema)],
     map(Schema, Conf, Roots, #{}).
 
 -spec map(schema(), hocon:config(), all | [name()]) ->
@@ -424,12 +226,12 @@ map(Schema, Conf, RootNames) ->
 -spec map(schema(), hocon:config(), all | [name()], opts()) ->
         {[proplists:property()], hocon:config()}.
 map(Schema, Conf, all, Opts) ->
-    map(Schema, Conf, root_names(Schema), Opts);
+    map(Schema, Conf, hocon_schema:root_names(Schema), Opts);
 map(Schema, Conf0, Roots0, Opts0) ->
     Opts = merge_opts(#{schema => Schema,
                         format => richmap
                        }, Opts0),
-    Roots = resolve_root_types(roots(Schema), Roots0),
+    Roots = resolve_root_types(hocon_schema:roots(Schema), Roots0),
     %% assert
     lists:foreach(fun({RootName, _RootSc}) ->
                           ok = assert_no_dot(Schema, RootName)
@@ -444,10 +246,10 @@ map(Schema, Conf0, Roots0, Opts0) ->
 
 %% @doc Apply environment variable overrides on top of the given Conf0
 merge_env_overrides(Schema, Conf0, all, Opts) ->
-    merge_env_overrides(Schema, Conf0, root_names(Schema), Opts);
+    merge_env_overrides(Schema, Conf0, hocon_schema:root_names(Schema), Opts);
 merge_env_overrides(Schema, Conf0, Roots0, Opts0) ->
     Opts = Opts0#{apply_override_envs => true}, %% force
-    Roots = resolve_root_types(roots(Schema), Roots0),
+    Roots = resolve_root_types(hocon_schema:roots(Schema), Roots0),
     Conf = filter_by_roots(Opts, Conf0, Roots),
     apply_envs(Schema, Conf, Opts, Roots).
 
@@ -634,17 +436,17 @@ map_field(?MAP(_Name, Type), FieldSchema, Value, Opts) ->
     Keys = maps_keys(unbox(Opts, Value)),
     FieldNames = [str(K) || K <- Keys],
     %% All objects in this map should share the same schema.
-    NewSc = override(FieldSchema, #{type => Type, mapping => undefined}),
+    NewSc = hocon_schema:override(FieldSchema, #{type => Type, mapping => undefined}),
     NewFields = [{FieldName, NewSc} || FieldName <- FieldNames],
     do_map(NewFields, Value, Opts, NewSc); %% start over
 map_field(?R_REF(Module, Ref), FieldSchema, Value, Opts) ->
     %% Switching to another module, good luck.
-    do_map(fields(Module, Ref), Value, Opts#{schema := Module}, FieldSchema);
+    do_map(hocon_schema:fields(Module, Ref), Value, Opts#{schema := Module}, FieldSchema);
 map_field(?REF(Ref), FieldSchema, Value, #{schema := Schema} = Opts) ->
-    Fields = fields(Schema, Ref),
+    Fields = hocon_schema:fields(Schema, Ref),
     do_map(Fields, Value, Opts, FieldSchema);
 map_field(Ref, FieldSchema, Value, #{schema := Schema} = Opts) when is_list(Ref) ->
-    Fields = fields(Schema, Ref),
+    Fields = hocon_schema:fields(Schema, Ref),
     do_map(Fields, Value, Opts, FieldSchema);
 map_field(?UNION(Types), Schema0, Value, Opts) ->
     %% union is not a boxed value
@@ -763,30 +565,8 @@ is_nullable(Opts, Schema) ->
         Maybe -> Maybe
     end.
 
-field_schema(Atom, type) when is_atom(Atom) -> Atom;
-field_schema(Atom, _Other) when is_atom(Atom) -> undefined;
-field_schema(Type, SchemaKey) when ?IS_TYPEREFL(Type) ->
-    field_schema(hoconsc:mk(Type), SchemaKey);
-field_schema(?MAP(_Name, _Type) = Map, SchemaKey) ->
-    field_schema(hoconsc:mk(Map), SchemaKey);
-field_schema(?LAZY(_) = Lazy, SchemaKey) ->
-    field_schema(hoconsc:mk(Lazy), SchemaKey);
-field_schema(Ref, SchemaKey) when is_list(Ref) ->
-    field_schema(hoconsc:mk(Ref), SchemaKey);
-field_schema(?REF(_) = Ref, SchemaKey) ->
-    field_schema(hoconsc:mk(Ref), SchemaKey);
-field_schema(?R_REF(_, _) = Ref, SchemaKey) ->
-    field_schema(hoconsc:mk(Ref), SchemaKey);
-field_schema(?ARRAY(_) = Array, SchemaKey) ->
-    field_schema(hoconsc:mk(Array), SchemaKey);
-field_schema(?UNION(_) = Union, SchemaKey) ->
-    field_schema(hoconsc:mk(Union), SchemaKey);
-field_schema(?ENUM(_) = Enum, SchemaKey) ->
-    field_schema(hoconsc:mk(Enum), SchemaKey);
-field_schema(FieldSchema, SchemaKey) when is_function(FieldSchema, 1) ->
-    FieldSchema(SchemaKey);
-field_schema(FieldSchema, SchemaKey) when is_map(FieldSchema) ->
-    maps:get(SchemaKey, FieldSchema, undefined).
+field_schema(Sc, Key) ->
+    hocon_schema:field_schema(Sc, Key).
 
 maybe_mapping(undefined, _) -> []; % no mapping defined for this field
 maybe_mapping(_, undefined) -> []; % no value retrieved for this field
@@ -903,7 +683,7 @@ is_path(_Schema, ?R_REF(Module, Name), Path) ->
 is_path(Schema, ?LAZY(Type), Path) ->
     is_path(Schema, Type, Path);
 is_path(Schema, ?ARRAY(Type), [Name | Path]) ->
-    case is_array_index(Name) of
+    case hocon_util:is_array_index(Name) of
         {true, _} -> is_path(Schema, Type, Path);
         false -> false
     end;
@@ -915,7 +695,7 @@ is_path(_Schema, _Type, _Path) ->
     false.
 
 is_path2(Schema, RefName, [Name | Path]) ->
-    Fields = fields(Schema, RefName),
+    Fields = hocon_schema:fields(Schema, RefName),
     case is_field(Fields, Name) of
         {true, Type} -> is_path(Schema, Type, Path);
         false -> false
@@ -956,7 +736,7 @@ apply_env(Ns, [{VarName, V} | More], RootName, Conf, Opts) ->
     NewConf =
         case Path0 =/= [] andalso bin(RootName) =:= bin(hd(Path0)) of
             true ->
-                Path = string:join(Path0, "."),
+                Path = lists:flatten(string:join(Path0, ".")),
                 %% It lacks schema info here, so we need to tag the value '$FROM_ENV_VAR'
                 %% and the value will be logged later when checking against schema
                 %% so we know if the value is sensitive or not.
@@ -1008,12 +788,6 @@ unbox(Boxed) ->
         false -> error({bad_richmap, Boxed})
     end.
 
-safe_unbox(MaybeBox) ->
-    case maps:get(?HOCON_V, MaybeBox, undefined) of
-        undefined -> ?EMPTY_MAP;
-        Value -> Value
-    end.
-
 boxit(#{format := map}, Value, _OldValue) -> Value;
 boxit(#{format := richmap}, Value, undefined) -> boxit(Value, ?NULL_BOX);
 boxit(#{format := richmap}, Value, Box) -> boxit(Value, Box).
@@ -1036,25 +810,19 @@ mkrich(Map, Box) when is_map(Map) ->
 mkrich(Val, Box) ->
     boxit(Val, Box).
 
-get_field(#{format := richmap}, Path, Conf) -> deep_get(Path, Conf);
-get_field(#{format := map}, Path, Conf) -> get_value(Path, Conf).
+get_field(#{format := richmap}, Path, Conf) -> hocon_maps:deep_get(Path, Conf);
+get_field(#{format := map}, Path, Conf) -> hocon_maps:get(Path, richmap_to_map(Conf)).
 
 %% put (maybe deep) value to map/richmap
 %% e.g. "path.to.my.value"
 put_value(_Opts, _Path, undefined, Conf) ->
     Conf;
 put_value(#{format := richmap} = Opts, Path, V, Conf) ->
-    deep_put(Opts, Path, V, Conf);
+    hocon_maps:deep_put(Path, V, Conf, Opts);
 put_value(#{format := map} = Opts, Path, V, Conf) ->
     plain_put(Opts, split(Path), V, Conf).
 
-split(Path) -> lists:flatten(do_split(str(Path))).
-
-do_split([]) -> [];
-do_split(Path) when ?IS_NON_EMPTY_STRING(Path) ->
-    [bin(I) || I <- string:tokens(Path, ".")];
-do_split([H | T]) ->
-    [do_split(H) | do_split(T)].
+split(Path) -> hocon_util:split_path(Path).
 
 validators(undefined) -> [];
 validators(Validator) when is_function(Validator) ->
@@ -1118,116 +886,15 @@ validation_errs(Opts, Context) ->
 plain_value(Value, #{format := map}) -> Value;
 plain_value(Value, #{format := richmap}) -> richmap_to_map(Value).
 
-%% @doc get a child node from richmap.
-%% Key (first arg) can be "foo.bar.baz" or ["foo.bar", "baz"] or ["foo", "bar", "baz"].
--spec deep_get(string() | [string()], hocon:config()) -> hocon:config() | undefined.
-deep_get(Path, Conf) ->
-    do_deep_get(split(Path), Conf).
-
-do_deep_get([], Value) ->
-    %% terminal value
-    Value;
-do_deep_get([H | T], EnclosingMap) ->
-    %% `value` must exist, must be a richmap otherwise
-    %% a bug in in the caller
-    Value = maps:get(?HOCON_V, EnclosingMap),
-    case is_map(Value) of
-        true ->
-            case maps:get(H, Value, undefined) of
-                undefined ->
-                    %% no such field
-                    undefined;
-                FieldValue ->
-                    do_deep_get(T, FieldValue)
-            end;
-        false ->
-            undefined
-    end.
-
-maybe_atom(#{atom_key := true}, Name) when is_binary(Name) ->
-    try
-        binary_to_existing_atom(Name, utf8)
-    catch
-        _ : _ ->
-            error({non_existing_atom, Name})
-    end;
-maybe_atom(_Opts, Name) ->
-    Name.
-
 -spec plain_put(opts(), [binary()], term(), hocon:confing()) -> hocon:config().
 plain_put(_Opts, [], Value, _Old) -> Value;
 plain_put(Opts, [Name | Path], Value, Conf0) ->
     GoDeep = fun(V) -> plain_put(Opts, Path, Value, V) end,
-    do_put(Opts, Conf0, Name, GoDeep).
-
-%% put unboxed value to the richmap box
-%% this function is called places where there is no boxing context
-%% so it has to accept unboxed value.
-deep_put(Opts, Path, Value, Conf) ->
-    put_rich(Opts, split(Path), Value, Conf).
-
-put_rich(_Opts, [], Value, Box) ->
-    boxit(Value, Box);
-put_rich(Opts, [Name | Path], Value, Box) ->
-    V0 = safe_unbox(Box),
-    GoDeep = fun(Elem) -> put_rich(Opts, Path, Value, Elem) end,
-    V = do_put(Opts, V0, Name, GoDeep),
-    boxit(V, Box).
-
-do_put(Opts, V, Name, GoDeep) ->
-    case maybe_array(V) andalso is_array_index(Name) of
-        {true, Index} -> update_array_element(V, Index, GoDeep);
-        false when is_map(V) -> update_map_field(Opts, V, Name, GoDeep);
-        false -> update_map_field(Opts, #{}, Name, GoDeep)
-    end.
-
-maybe_array(V) when is_list(V) -> true;
-maybe_array(V) -> V =:= ?EMPTY_MAP.
-
-update_array_element(?EMPTY_MAP, Index, GoDeep) ->
-    update_array_element([], Index, GoDeep);
-update_array_element(List, Index, GoDeep) when is_list(List) ->
-    hocon_util:update_array_element(List, Index, GoDeep).
-
-update_map_field(Opts, Map, FieldName, GoDeep) ->
-    FieldV0 = maps:get(FieldName, Map, ?EMPTY_MAP),
-    FieldV = GoDeep(FieldV0),
-    Map1 = maps:without([FieldName], Map),
-    Map1#{maybe_atom(Opts, FieldName) => FieldV}.
-
-%% {true, integer()} if yes, otherwise false
-is_array_index(L) when is_list(L) ->
-    is_array_index(list_to_binary(L));
-is_array_index(I) -> hocon_util:is_array_index(I).
-
-check_indexed_array(List) ->
-    case check_indexed_array(List, [], []) of
-        {Good, []} -> check_index_seq(1, lists:keysort(1, Good), []);
-        {_, Bad} -> {error, #{bad_array_index_keys => Bad}}
-    end.
-
-check_indexed_array([], Good, Bad) -> {Good, Bad};
-check_indexed_array([{I, V} | Rest], Good, Bad) ->
-    case is_array_index(I) of
-        {true, Index} -> check_indexed_array(Rest, [{Index, V} | Good], Bad);
-        false -> check_indexed_array(Rest, Good, [I | Bad])
-    end.
-
-check_index_seq(_, [], Acc) ->
-    {ok, lists:reverse(Acc)};
-check_index_seq(I, [{Index, V} | Rest], Acc) ->
-    case I =:= Index of
-        true ->
-            check_index_seq(I + 1, Rest, [V | Acc]);
-        false ->
-            {error, #{expected_index => I,
-                      got_index => Index}}
-    end.
+    hocon_maps:do_put(Conf0, Name, GoDeep, Opts).
 
 type_hint(B) when is_binary(B) -> string; %% maybe secret, do not hint value
 type_hint(X) -> X.
 
-%% @doc Convert richmap to plain-map.
 richmap_to_map(MaybeRichMap) ->
     hocon_util:richmap_to_map(MaybeRichMap).
 
@@ -1241,51 +908,6 @@ drop_nulls(Opts, Map) when is_map(Map) ->
                             _ -> true
                         end
                 end, Map).
-
-%% @doc Get (maybe nested) field value for the given path.
-%% This function works for both plain and rich map,
-%% And it always returns plain map.
--spec get_value(string(), hocon:config()) -> term().
-get_value(Path, Conf) ->
-    %% ensure plain map
-    do_get(split(Path), richmap_to_map(Conf)).
-
-do_get([], Conf) ->
-    %% value as-is
-    Conf;
-do_get(_, undefined) ->
-    undefined;
-do_get([H | T], Conf) ->
-    do_get(T, try_get(H, Conf)).
-
-try_get(Key, Conf) when is_map(Conf) ->
-    case maps:get(Key, Conf, undefined) of
-        undefined ->
-            try binary_to_existing_atom(Key, utf8) of
-                AtomKey -> maps:get(AtomKey, Conf, undefined)
-            catch
-                error : badarg ->
-                    undefined
-            end;
-        Value ->
-            Value
-    end;
-try_get(Key, Conf) when is_list(Conf) ->
-    try binary_to_integer(Key) of
-        N ->
-            lists:nth(N, Conf)
-    catch
-        error : badarg ->
-            undefined
-    end.
-
-
--spec get_value(string(), hocon:config(), term()) -> term().
-get_value(Path, Config, Default) ->
-    case get_value(Path, Config) of
-        undefined -> Default;
-        V -> V
-    end.
 
 assert_no_error(Schema, List) ->
     case find_errors(List) of
@@ -1307,55 +929,6 @@ do_find_error([{error, E} | More], Errors) ->
 do_find_error([_ | More], Errors) ->
     do_find_error(More, Errors).
 
-find_structs(Schema, Fields) ->
-    find_structs(Schema, Fields, #{}, _ValueStack = [], _TypeStack = []).
-
-find_structs(Schema, #{fields := Fields}, Acc, Stack, TStack) ->
-    find_structs(Schema, Fields, Acc, Stack, TStack);
-find_structs(_Schema, [], Acc, _Stack, _TStack) -> Acc;
-find_structs(Schema, [{FieldName, FieldSchema} | Fields], Acc0, Stack, TStack) ->
-    Type = hocon_schema:field_schema(FieldSchema, type),
-    Acc = find_structs_per_type(Schema, Type, Acc0, [str(FieldName) | Stack], TStack),
-    find_structs(Schema, Fields, Acc, Stack, TStack).
-
-find_structs_per_type(Schema, Name, Acc, Stack, TStack) when is_list(Name) ->
-    find_ref(Schema, Name, Acc, Stack, TStack);
-find_structs_per_type(Schema, ?REF(Name), Acc, Stack, TStack) ->
-    find_ref(Schema, Name, Acc, Stack, TStack);
-find_structs_per_type(_Schema, ?R_REF(Module, Name), Acc, Stack, TStack) ->
-    find_ref(Module, Name, Acc, Stack, TStack);
-find_structs_per_type(Schema, ?LAZY(Type), Acc, Stack, TStack) ->
-    find_structs_per_type(Schema, Type, Acc, Stack, TStack);
-find_structs_per_type(Schema, ?ARRAY(Type), Acc, Stack, TStack) ->
-    find_structs_per_type(Schema, Type, Acc, ["$INDEX" | Stack], TStack);
-find_structs_per_type(Schema, ?UNION(Types), Acc, Stack, TStack) ->
-    lists:foldl(fun(T, AccIn) ->
-                        find_structs_per_type(Schema, T, AccIn, Stack, TStack)
-                end, Acc, Types);
-find_structs_per_type(Schema, ?MAP(Name, Type), Acc, Stack, TStack) ->
-    find_structs_per_type(Schema, Type, Acc, ["$" ++ str(Name) | Stack], TStack);
-find_structs_per_type(_Schema, _Type, Acc, _Stack, _TStack) ->
-    Acc.
-
-find_ref(Schema, Name, Acc, Stack, TStack) ->
-    Namespace = hocon_schema:namespace(Schema),
-    Key = {Namespace, Name},
-    Path = path(Stack),
-    Paths =
-        case maps:find(Key, Acc) of
-            {ok, #{paths := Ps}} -> Ps;
-            error -> #{}
-        end,
-    case lists:member(Key, TStack) of
-        true ->
-            %% loop reference, break here, otherwise never exit
-            Acc;
-        false ->
-            Fields0 = fields_and_meta(Schema, Name),
-            Fields = Fields0#{paths => Paths#{Path => true}},
-            find_structs(Schema, Fields, Acc#{Key => Fields}, Stack, [Key | TStack])
-    end.
-
 only_fill_defaults(#{only_fill_defaults := true}) -> true;
 only_fill_defaults(_) -> false.
 
@@ -1366,3 +939,26 @@ ensure_bin_str(Value) when is_list(Value) ->
     end;
 ensure_bin_str(Value) -> Value.
 
+check_indexed_array(List) ->
+    case check_indexed_array(List, [], []) of
+        {Good, []} -> check_index_seq(1, lists:keysort(1, Good), []);
+        {_, Bad} -> {error, #{bad_array_index_keys => Bad}}
+    end.
+
+check_indexed_array([], Good, Bad) -> {Good, Bad};
+check_indexed_array([{I, V} | Rest], Good, Bad) ->
+    case hocon_util:is_array_index(I) of
+        {true, Index} -> check_indexed_array(Rest, [{Index, V} | Good], Bad);
+        false -> check_indexed_array(Rest, Good, [I | Bad])
+    end.
+
+check_index_seq(_, [], Acc) ->
+    {ok, lists:reverse(Acc)};
+check_index_seq(I, [{Index, V} | Rest], Acc) ->
+    case I =:= Index of
+        true ->
+            check_index_seq(I + 1, Rest, [V | Acc]);
+        false ->
+            {error, #{expected_index => I,
+                      got_index => Index}}
+    end.

--- a/test/hocon_cuttlefish_compatibility_tests.erl
+++ b/test/hocon_cuttlefish_compatibility_tests.erl
@@ -178,11 +178,11 @@ management_test_() ->
 
 load_hocon(File) ->
     {ok, C} = hocon:load(File, #{format => richmap}),
-    hocon_schema:generate(emqx_schema, C).
+    hocon_tconf:generate(emqx_schema, C).
 
 load_hocon(File, Schema) ->
     {ok, C} = hocon:load(File, #{format => richmap}),
-    hocon_schema:generate(Schema, C).
+    hocon_tconf:generate(Schema, C).
 
 load_cuttlefish(File) ->
     cuttlefish_generator:map(cuttlefish_schema:files(["sample-schemas/emqx.schema"]),

--- a/test/hocon_maps_tests.erl
+++ b/test/hocon_maps_tests.erl
@@ -1,0 +1,47 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(hocon_maps_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("hocon_private.hrl").
+
+deep_put_test_() ->
+    F = fun(Str, Key, Value) ->
+                {ok, M} = hocon:binary(Str, #{format => richmap}),
+                NewM = hocon_maps:deep_put(Key, Value, M, #{}),
+                deep_get(Key, NewM, ?HOCON_V)
+        end,
+    [ ?_assertEqual(2, F("a=1", "a", 2))
+    , ?_assertEqual(2, F("a={b=1}", "a.b", 2))
+    , ?_assertEqual(#{x => 1}, F("a={b=1}", "a.b", #{x => 1}))
+    ].
+
+deep_get_test_() ->
+    F = fun(Str, Key, Param) ->
+                {ok, M} = hocon:binary(Str, #{format => richmap}),
+                deep_get(Key, M, Param)
+        end,
+    [ ?_assertEqual(1, F("a=1", "a", ?HOCON_V))
+    , ?_assertMatch(#{line := 1}, F("a=1", "a", ?METADATA))
+    , ?_assertEqual(1, F("a={b=1}", "a.b", ?HOCON_V))
+    , ?_assertEqual(undefined, F("a={b=1}", "a.c", ?HOCON_V))
+    ].
+
+deep_get(Path, Conf, Param) ->
+    case hocon_maps:deep_get(Path, Conf) of
+        undefined -> undefined;
+        Map -> maps:get(Param, Map, undefined)
+    end.

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -499,7 +499,7 @@ files_test() ->
     ?assertEqual("b_2.conf", Filename(deep_get("b", Conf, ?METADATA))).
 
 deep_get(Key, Conf, Tag) ->
-    Map = hocon_schema:deep_get(Key, Conf),
+    Map = hocon_maps:deep_get(Key, Conf),
     maps:get(Tag, Map).
 
 utf8_test() ->

--- a/test/hocon_util_tests.erl
+++ b/test/hocon_util_tests.erl
@@ -1,0 +1,31 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(hocon_util_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+richmap_to_map_test_() ->
+    F = fun(Str) -> {ok, M} = hocon:binary(Str, #{format => richmap}),
+                    richmap_to_map(M) end,
+    [ ?_assertEqual(#{<<"a">> => #{<<"b">> => 1}}, F("a.b=1"))
+    , ?_assertEqual(#{<<"a">> => #{<<"b">> => [1, 2, 3]}}, F("a.b = [1,2,3]"))
+    , ?_assertEqual(#{<<"a">> =>
+                      #{<<"b">> => [1, 2, #{<<"x">> => <<"foo">>}]}}, F("a.b = [1,2,{x=foo}]"))
+    ].
+
+richmap_to_map(Map) ->
+    hocon_util:richmap_to_map(Map).


### PR DESCRIPTION
`hocon_schema` module is split to:
1. `hocon_maps`: for map and richmap
2. `hocon_schema`: for hocon schema itself
3. `hocon_tconf`: as in typesafe-config for config mapping and checking