### PR TITLE
refactor: moved deep_merge/2 to hocon_maps and deleted deep_map_merge/2

### DIFF
--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -798,7 +798,7 @@ boxit(Value, Box) -> Box#{?HOCON_V => Value}.
 maybe_mkrich(#{format := map}, Value, _Box) ->
     Value;
 maybe_mkrich(#{format := richmap}, Value, Box) ->
-    hocon_util:deep_merge(Box, mkrich(Value, Box)).
+    hocon_maps:deep_merge(Box, mkrich(Value, Box)).
 
 mkrich(Arr, Box) when is_list(Arr) ->
     NewArr = [mkrich(I, Box) || I <- Arr],

--- a/src/hocon_token.erl
+++ b/src/hocon_token.erl
@@ -145,7 +145,7 @@ parse(Tokens, Ctx) ->
 include(#{?HOCON_T := object} = O, Ctx) ->
     NewV = do_include(value_of(O), [], Ctx, hocon_util:get_stack(path, Ctx)),
     Filename = hd(hocon_util:get_stack(filename, Ctx)),
-    hocon_util:deep_merge(O, box_v(Filename, NewV)).
+    hocon_maps:deep_merge(O, box_v(Filename, NewV)).
 
 do_include([], Acc, _Ctx, _CurrentPath) ->
     lists:reverse(Acc);
@@ -159,23 +159,23 @@ do_include([#{?HOCON_T := include}=Include | More], Acc, Ctx, CurrentPath) ->
     end;
 do_include([#{?HOCON_T := variable}=V | More], Acc, Ctx, CurrentPath) ->
     VarWithAbsPath = abspath(value_of(V), hocon_util:get_stack(path, Ctx)),
-    NewV = hocon_util:deep_merge(V, box_v(filename(Ctx), VarWithAbsPath)),
+    NewV = hocon_maps:deep_merge(V, box_v(filename(Ctx), VarWithAbsPath)),
     do_include(More, [NewV | Acc], Ctx, CurrentPath);
 do_include([{Key, #{?HOCON_T := T}=X} | More], Acc, Ctx, CurrentPath) when ?IS_VALUE_LIST(T) ->
-    NewKey = hocon_util:deep_merge(Key, box(filename(Ctx))),
+    NewKey = hocon_maps:deep_merge(Key, box(filename(Ctx))),
     NewValue = do_include(value_of(X), [], Ctx, [Key | CurrentPath]),
-    NewX = hocon_util:deep_merge(X, box_v(filename(Ctx), line_of(Key), NewValue)),
+    NewX = hocon_maps:deep_merge(X, box_v(filename(Ctx), line_of(Key), NewValue)),
     do_include(More, [{NewKey, NewX} | Acc], Ctx, CurrentPath);
 do_include([#{?HOCON_T := T}=X | More], Acc, Ctx, CurrentPath) when ?IS_VALUE_LIST(T) ->
     NewValue = do_include(value_of(X), [], Ctx, CurrentPath),
-    do_include(More, [hocon_util:deep_merge(X, box_v(filename(Ctx), NewValue)) | Acc],
+    do_include(More, [hocon_maps:deep_merge(X, box_v(filename(Ctx), NewValue)) | Acc],
                Ctx, CurrentPath);
 do_include([{Key, #{?HOCON_T := _T}=X} | More], Acc, Ctx, CurrentPath) ->
-    NewKey = hocon_util:deep_merge(Key, box(filename(Ctx))),
-    NewX = hocon_util:deep_merge(X, box(filename(Ctx), line_of(Key))),
+    NewKey = hocon_maps:deep_merge(Key, box(filename(Ctx))),
+    NewX = hocon_maps:deep_merge(X, box(filename(Ctx), line_of(Key))),
     do_include(More, [{NewKey, NewX} | Acc], Ctx, CurrentPath);
 do_include([#{?HOCON_T := _T}=X | More], Acc, Ctx, CurrentPath) ->
-    NewX = hocon_util:deep_merge(X, box(filename(Ctx))),
+    NewX = hocon_maps:deep_merge(X, box(filename(Ctx))),
     do_include(More, [NewX | Acc], Ctx, CurrentPath).
 
 box_v(Filename, Value) ->

--- a/src/hocon_util.erl
+++ b/src/hocon_util.erl
@@ -16,56 +16,16 @@
 
 -module(hocon_util).
 
--export([deep_map_merge/2, deep_merge/2]).
 -export([pipeline_fun/1, pipeline/3]).
 -export([stack_multiple_push/2, stack_push/2, get_stack/2, top_stack/2]).
 -export([is_same_file/2, real_file_name/1]).
 -export([is_richmap/1, richmap_to_map/1]).
 -export([env_prefix/1, is_array_index/1]).
--export([update_array_element/3]).
 -export([split_path/1]).
 
 -include("hocon_private.hrl").
 
 -define(IS_NON_EMPTY_STRING(X), (is_list(X) andalso X =/= [] andalso is_integer(hd(X)))).
-
-deep_map_merge(M1, M2) when is_map(M1), is_map(M2) ->
-    do_deep_merge(M1, M2, fun deep_map_merge/2);
-deep_map_merge(_, Override) ->
-    Override.
-
-do_deep_merge(M1, M2, GoDeep) when is_map(M1), is_map(M2) ->
-    maps:fold(
-        fun(K, V2, Acc) ->
-                V1 = maps:get(K, Acc, undefined),
-                NewV = do_deep_merge(V1, V2, GoDeep),
-                Acc#{K => NewV}
-        end, M1, M2);
-do_deep_merge(V1, V2, GoDeep) ->
-    GoDeep(V1, V2).
-
-deep_merge(#{?HOCON_T := array, ?HOCON_V := V1} = Base,
-                 #{?HOCON_T := object, ?HOCON_V := V2} = Top) ->
-    NewV = deep_merge2(V1, V2),
-    case is_list(NewV) of
-        true ->
-            %% after merge, it's still an array, only update the value
-            %% keep the metadata
-            Base#{?HOCON_V => NewV};
-        false ->
-            %% after merge, it's no longer an array, return all old
-            Top
-    end;
-deep_merge(V1, V2) ->
-    deep_merge2(V1, V2).
-
-deep_merge2(M1, M2) when is_map(M1) andalso is_map(M2) ->
-    do_deep_merge(M1, M2, fun deep_merge/2);
-deep_merge2(V1, V2) ->
-    case is_list(V1) andalso is_indexed_array(V2) of
-        true -> merge_array(V1, V2);
-        false -> V2
-    end.
 
 pipeline_fun(Steps) ->
     fun (Input) -> pipeline(Input, #{}, Steps) end.
@@ -144,57 +104,6 @@ is_array_index(I) when is_binary(I) ->
         _ : _ ->
             false
     end.
-
-is_indexed_array(M) when is_map(M) ->
-    lists:all(fun(K) -> case is_array_index(K) of
-                            {true, _} -> true;
-                            _ -> false
-                        end
-              end, maps:keys(M));
-is_indexed_array(_) ->
-    false.
-
-%% convert indexed array to key-sorted tuple {index, value} list
-indexed_array_as_list(M) when is_map(M) ->
-    lists:keysort(
-      1, lists:map(fun({K, V}) ->
-                           {true, I} = is_array_index(K),
-                           {I, V}
-                   end, maps:to_list(M))).
-
-merge_array(Array, Top) when is_list(Array) ->
-    ToMerge = indexed_array_as_list(Top),
-    do_merge_array(Array, ToMerge).
-
-do_merge_array(Array, []) -> Array;
-do_merge_array(Array, [{I, Value} | Rest]) ->
-    GoDeep = fun(Elem) -> deep_merge(Elem, Value) end,
-    NewArray = update_array_element(Array, I, GoDeep),
-    do_merge_array(NewArray, Rest).
-
-update_array_element(List, Index, GoDeep) when is_list(List) ->
-    MinIndex = 1,
-    MaxIndex = length(List) + 1,
-    Index < MinIndex andalso throw({bad_array_index, "index starts from 1"}),
-    Index > MaxIndex andalso
-    begin
-        Msg0 = io_lib:format("should not be greater than ~p.", [MaxIndex]),
-        Msg1 = case Index > 9 of
-                   true ->
-                       "~nEnvironment variable overrides applied in alphabetical "
-                       "make sure to use zero paddings such as '02' to ensure "
-                       "10 is ordered after it";
-                   false ->
-                       []
-               end,
-        throw({bad_array_index, [Msg0, Msg1]})
-    end,
-    {Head, Tail0} = lists:split(Index - 1, List),
-    {Nth, Tail} = case Tail0 of
-                      [] -> {#{}, []};
-                      [H | T] -> {H, T}
-                  end,
-    Head ++ [GoDeep(Nth) | Tail].
 
 split_path(Path) ->
     lists:flatten(do_split(str(Path))).


### PR DESCRIPTION
deep_merge/2 is generic enough for deep_map_merge/2
deep_map_merge was to merge map array elements when the array
from the second arg is a indexed-array

all the existing cases where deep_map_merge was used had no
indexed-array