### PR TITLE
feat: make json compatible schema dump

### DIFF
--- a/include/hocon.hrl
+++ b/include/hocon.hrl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/include/hocon_private.hrl
+++ b/include/hocon_private.hrl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/include/hoconsc.hrl
+++ b/include/hoconsc.hrl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/sample-schemas/demo_schema3.erl
+++ b/sample-schemas/demo_schema3.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/sample-schemas/emqx_schema.erl
+++ b/sample-schemas/emqx_schema.erl
@@ -25,7 +25,7 @@
 % workaround: prevent being recognized as unused functions
 -export([to_duration/1, to_duration_s/1, to_bytesize/1,
          to_flag/1, to_percent/1, to_comma_separated_list/1,
-         to_bar_separated_list/1, to_ip_port/1]).
+         to_bar_separated_list/1, to_ip_port/1, namespace/0]).
 
 -behaviour(hocon_schema).
 
@@ -37,6 +37,8 @@
 -export([t/1, t/3, ref/1]).
 -export([conf_get/2, conf_get/3, keys/2, filter/1]).
 -export([ssl/2, tr_ssl/2, tr_password_hash/2]).
+
+namespace() -> "emqx".
 
 roots() -> ["cluster", "node", "rpc", "log", "lager",
              "acl", "mqtt",

--- a/src/hocon.erl
+++ b/src/hocon.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -160,7 +160,7 @@ docgen(ParsedArgs) ->
             stop_deactivate();
         Module ->
             Title = proplists:get_value(doctitle, ParsedArgs),
-            io:format(user, "~s", [hocon_schema_doc:gen(Module, Title)])
+            io:format(user, "~s", [hocon_schema_md:gen(Module, Title)])
     end.
 
 load_schema(ParsedArgs) ->

--- a/src/hocon_md.erl
+++ b/src/hocon_md.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_postprocess.erl
+++ b/src/hocon_postprocess.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2020 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2020-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_pp.erl
+++ b/src/hocon_pp.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_scanner.xrl
+++ b/src/hocon_scanner.xrl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2020 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2020-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -86,6 +86,7 @@
          , sensitive => boolean()
          , desc => iodata()
          , hidden => boolean() %% hide it from doc generation
+         , extra => map() %% transparent metadata
          }.
 
 -type field() :: {name(), typefunc() | field_schema()}.

--- a/src/hocon_schema_builtin.erl
+++ b/src/hocon_schema_builtin.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_schema_cuttlefish.erl
+++ b/src/hocon_schema_cuttlefish.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_schema_html.erl
+++ b/src/hocon_schema_html.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_schema_json.erl
+++ b/src/hocon_schema_json.erl
@@ -1,0 +1,124 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(hocon_schema_json).
+
+-export([gen/1]).
+
+-include("hoconsc.hrl").
+-include("hocon_private.hrl").
+
+%% @doc Generate a JSON compatible list of `map()'s.
+-spec gen(hocon_schema:schema()) -> [map()].
+gen(Schema) ->
+    {RootNs, RootFields, Structs} = hocon_schema:find_structs(Schema),
+    [ gen_struct(RootNs, RootNs, "Root Config Keys", #{fields => RootFields})
+    | lists:map(fun({Ns, Name, Fields}) -> gen_struct(RootNs, Ns, Name, Fields) end, Structs)
+    ].
+
+gen_struct(RootNs, Ns0, Name, #{fields := Fields} = Meta) ->
+    Ns = case RootNs =:= Ns0 of
+             true -> undefined;
+             false -> Ns0
+         end,
+    Paths = case Meta of
+                #{paths := Ps} -> lists:sort(maps:keys(Ps));
+                _ -> []
+            end,
+    FullNameDisplay = fmt_ref(Ns, Name),
+    S0 = #{ full_name => bin(FullNameDisplay)
+          , paths => [bin(P) || P <- Paths]
+          , envs => [hocon_util:path_to_env_name(P) || P <- Paths]
+          , fields => fmt_fields(Ns, Fields)
+          },
+    case Meta of
+        #{desc := StructDoc} -> S0#{desc => bin(StructDoc)};
+        _ -> S0
+    end.
+
+fmt_fields(_Ns, []) -> [];
+fmt_fields(Ns, [{Name, FieldSchema} | Fields]) ->
+    case hocon_schema:field_schema(FieldSchema, hidden) of
+        true -> fmt_fields(Ns, Fields);
+        _ -> [fmt_field(Ns, Name, FieldSchema) | fmt_fields(Ns, Fields)]
+    end.
+
+fmt_field(Ns, Name, FieldSchema) ->
+    L = [ {name, bin(Name)}
+        , {type, fmt_type(Ns, hocon_schema:field_schema(FieldSchema, type))}
+        , {default, fmt_default(hocon_schema:field_schema(FieldSchema, default))}
+        , {desc, bin(hocon_schema:field_schema(FieldSchema, desc))}
+        , {extra, hocon_schema:field_schema(FieldSchema, extra)}
+        ],
+    maps:from_list([{K, V} || {K, V} <- L, V =/= undefined]).
+
+fmt_default(undefined) -> undefined;
+fmt_default(Value) ->
+    case hocon_pp:do(Value, #{newline => "", embedded => true}) of
+        [OneLine] -> #{oneliner => true, hocon => bin(OneLine)};
+        Lines -> #{oneliner => false, hocon => bin([[L, "\n"] || L <- Lines])}
+    end.
+
+fmt_type(_Ns, A) when is_atom(A) ->
+    #{ kind => singleton
+     , name => bin(A)
+     };
+fmt_type(Ns, Ref) when is_list(Ref) ->
+    fmt_type(Ns, ?REF(Ref));
+fmt_type(Ns, ?REF(Ref)) ->
+    #{ kind => struct
+     , name => bin(fmt_ref(Ns, Ref))
+     };
+fmt_type(_Ns, ?R_REF(Module, Ref)) ->
+    fmt_type(hocon_schema:namespace(Module), ?REF(Ref));
+fmt_type(Ns, ?ARRAY(T)) ->
+    #{ kind => array
+     , elements => fmt_type(Ns, T)
+     };
+fmt_type(Ns, ?UNION(Ts)) ->
+    #{ kind => union
+     , members => [fmt_type(Ns, T) || T <- Ts]
+     };
+fmt_type(_Ns, ?ENUM(Symbols)) ->
+    #{ kind => enum
+     , symbols => [bin(S) || S <- Symbols]
+     };
+fmt_type(Ns, ?LAZY(T)) ->
+    fmt_type(Ns, T);
+fmt_type(Ns, ?MAP(Name, T)) ->
+    #{ kind => map
+     , name => bin(Name)
+     , values => fmt_type(Ns, T)
+     };
+fmt_type(_Ns, {'$type_refl', #{name := Type}}) ->
+    #{kind => primitive,
+      name => bin(lists:flatten(Type))
+     }.
+
+fmt_ref(undefined, Name) -> Name;
+fmt_ref(Ns, Name) ->
+    %% when namespace is the same as reference name
+    %% we do not prepend the reference link with namespace
+    %% because the root name is already unique enough
+    case bin(Ns) =:= bin(Name) of
+        true -> bin(Ns);
+        false -> [bin(Ns), ":", bin(Name)]
+    end.
+
+bin(undefined) -> undefined;
+bin(S) when is_list(S) -> unicode:characters_to_binary(S, utf8);
+bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
+bin(B) when is_binary(B) -> B.

--- a/src/hocon_schema_json.erl
+++ b/src/hocon_schema_json.erl
@@ -41,7 +41,6 @@ gen_struct(RootNs, Ns0, Name, #{fields := Fields} = Meta) ->
     FullNameDisplay = fmt_ref(Ns, Name),
     S0 = #{ full_name => bin(FullNameDisplay)
           , paths => [bin(P) || P <- Paths]
-          , envs => [hocon_util:path_to_env_name(P) || P <- Paths]
           , fields => fmt_fields(Ns, Fields)
           },
     case Meta of

--- a/src/hocon_schema_md.erl
+++ b/src/hocon_schema_md.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_schema_md.erl
+++ b/src/hocon_schema_md.erl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(hocon_schema_doc).
+-module(hocon_schema_md).
 
 -export([gen/2]).
 

--- a/src/hocon_token.erl
+++ b/src/hocon_token.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_util.erl
+++ b/src/hocon_util.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/src/hocon_util.erl
+++ b/src/hocon_util.erl
@@ -106,7 +106,7 @@ is_array_index(I) when is_binary(I) ->
     end.
 
 path_to_env_name(Path) ->
-    bin(lists:join("__", split_path(Path))).
+    string:uppercase(bin(lists:join("__", split_path(Path)))).
 
 split_path(Path) ->
     lists:flatten(do_split(str(Path))).

--- a/src/hocon_util.erl
+++ b/src/hocon_util.erl
@@ -21,7 +21,7 @@
 -export([is_same_file/2, real_file_name/1]).
 -export([is_richmap/1, richmap_to_map/1]).
 -export([env_prefix/1, is_array_index/1]).
--export([split_path/1]).
+-export([split_path/1, path_to_env_name/1]).
 
 -include("hocon_private.hrl").
 
@@ -104,6 +104,9 @@ is_array_index(I) when is_binary(I) ->
         _ : _ ->
             false
     end.
+
+path_to_env_name(Path) ->
+    bin(lists:join("__", split_path(Path))).
 
 split_path(Path) ->
     lists:flatten(do_split(str(Path))).

--- a/src/hoconsc.erl
+++ b/src/hoconsc.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/hocon_cli_tests.erl
+++ b/test/hocon_cli_tests.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/hocon_cuttlefish_compatibility_tests.erl
+++ b/test/hocon_cuttlefish_compatibility_tests.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/hocon_pp_tests.erl
+++ b/test/hocon_pp_tests.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/hocon_schema_html_tests.erl
+++ b/test/hocon_schema_html_tests.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/hocon_schema_md_tests.erl
+++ b/test/hocon_schema_md_tests.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/hocon_schema_md_tests.erl
+++ b/test/hocon_schema_md_tests.erl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(hocon_schema_doc_tests).
+-module(hocon_schema_md_tests).
 
 -include_lib("eunit/include/eunit.hrl").
 

--- a/test/hocon_schema_md_tests.erl
+++ b/test/hocon_schema_md_tests.erl
@@ -17,6 +17,7 @@
 -module(hocon_schema_md_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("typerefl/include/types.hrl").
 
 no_crash_test_() ->
     [{"demo_schema", gen(demo_schema)},
@@ -31,10 +32,20 @@ no_crash_test_() ->
       gen(#{namespace => dummy,
             roots => [foo],
             fields => #{foo => [{"f1", hoconsc:mk(hoconsc:ref(emqx_schema, "zone"))}]}
+           })},
+     {"multi-line-default",
+      gen(#{ namespace => "rootns"
+           , roots => [foo]
+           , fields => #{foo => [{"f1", hoconsc:mk(hoconsc:ref(emqx_schema, "etcd"),
+                                                   #{default => #{<<"server">> => <<"localhost">>,
+                                                                  <<"prefix">> => <<"prefix">>,
+                                                                  <<"node_ttl">> => "100s",
+                                                                  <<"ssl">> => <<>>
+                                                                 }})}]}
            })}
     ].
 
-gen(Schema) -> fun() -> hocon_schema_doc:gen(Schema, "test") end.
+gen(Schema) -> fun() -> hocon_schema_md:gen(Schema, "test") end.
 
 find_structs_test() ->
     {demo_schema3, _Roots, Subs} = hocon_schema:find_structs(demo_schema3),

--- a/test/hocon_test_lib.erl
+++ b/test/hocon_test_lib.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.


### PR DESCRIPTION
fixes https://github.com/emqx/hocon/issues/174
make possible to dump hocon schema to a JSON compatible map.
i.e. this lib itself does not have a JSON lib dependency,
the return value of `hocon_schema_json:gen/1` can be fed to any JSON encoder jsx, jiffy, jsone etc. 

this  JSON dump can be useful in frontend  UI  rendering for post forms .
also, with a bit of javascrpt programming, the configuration document page can be rendered directly from the JSON instead of rendering a markdown file.