### PR TITLE
fix: better type check exception

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {minimum_otp_vsn, "21.0"}.
 
 {deps, [ {getopt, "1.0.1"}
-       , {typerefl, {git, "https://github.com/k32/typerefl.git", {tag, "0.8.5"}}}
+       , {typerefl, {git, "https://github.com/k32/typerefl.git", {tag, "0.8.7"}}}
        ]}.
 
 {edoc_opts, [{preprocess, true}]}.
@@ -25,7 +25,7 @@
 
 {profiles,
   [ {test,
-        [ {deps, [ {proper, "1.3.0"}
+        [ {deps, [ {proper, "1.4.0"}
                  , {cuttlefish, {git, "https://github.com/emqx/cuttlefish.git", {tag, "v3.3.5"}}}
                  , {erlymatch, {git, "https://github.com/zmstone/erlymatch.git", {tag, "1.1.0"}}}
                  ]}

--- a/sample-schemas/emqx_auth_mongo_schema.erl
+++ b/sample-schemas/emqx_auth_mongo_schema.erl
@@ -39,8 +39,7 @@ fields("mongo") ->
     ];
 
 fields("ssl") ->
-    [ {"enable", emqx_schema:t(emqx_schema:flag(), undefined, false)}
-    ] ++ emqx_schema:ssl(undefined, #{verify => verify_none});
+    emqx_schema:ssl(undefined, #{verify => verify_none});
 
 fields("auth_query") ->
     [ {"collection", emqx_schema:t(string(), undefined, "mqtt_user")}

--- a/sample-schemas/emqx_schema.erl
+++ b/sample-schemas/emqx_schema.erl
@@ -310,7 +310,7 @@ fields("wss_listener") ->
     % @fixme
     Ssl = ssl(undefined, #{depth => 10
                          , reuse_sessions => true}) ++ listener_fields(),
-    Settings = lists:ukeymerge(1, Ssl, fields("ws_listener")),
+    Settings = lists:ukeysort(1, Ssl ++ fields("ws_listener")),
     lists:keydelete("high_watermark", 1, Settings);
 
 fields("deflate_opts") ->

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -510,7 +510,16 @@ unknown_fields_test_() ->
     Conf = "person.id.num=123,person.name=mike",
     {ok, M} = hocon:binary(Conf, #{format => richmap}),
     ?GEN_VALIDATION_ERR(#{reason := unknown_fields,
-                          unknown := [{<<"name">>, #{line := 1}}]
+                          expected_fields := [],
+                          unknown_fields := [{<<"name">>, #{line := 1}}]
+                         }, hocon_tconf:map(demo_schema, M, all)).
+
+expected_fields_not_matched_test_() ->
+    Conf = "\nperson.name=mike",
+    {ok, M} = hocon:binary(Conf, #{format => richmap}),
+    ?GEN_VALIDATION_ERR(#{reason := unknown_fields,
+                          expected_fields := [<<"id">>],
+                          unknown_fields := [{<<"name">>, #{line := 2}}]
                          }, hocon_tconf:map(demo_schema, M, all)).
 
 required_field_test() ->


### PR DESCRIPTION
prior to this change, all expected fields are hinted in the exception
when there is an unknown field name.
e.g.
input = [a, b, x], schema = [a, b, c]
hint: unknnwon = [x], expected = [a, b, c]

with this fix, the fields which matches the schema are excluded from
the hint
e.g.
input = [a, b, x], schema = [a, b, c]
hint: unknown = [x], expected = [c]