### PR TITLE
fix(log): convert error message to binary before logging

### DIFF
--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -380,8 +380,8 @@ map_fields([{FieldName, FieldSchema} | Fields], Conf0, Acc, Opts) ->
                         field => FieldName,
                         path => try path(Opts) catch _ : _ -> [] end,
                         exception => E},
-                catch log(Opts, error, io_lib:format("input-config:~n~p~n~p~n",
-                                                     [FieldValue, Err])),
+                catch log(Opts, error, bin(io_lib:format("input-config:~n~p~n~p~n",
+                                                         [FieldValue, Err]))),
                 erlang:raise(C, Err, St)
         end,
     Conf = put_value(Opts, FieldName, unbox(Opts, FValue), Conf0),


### PR DESCRIPTION
Without converting the message iolist to a binary, the output error
message is hard to read.

Example:

```
[error] [105,110,112,117,116,45,99,111,110,102,105,103,58,10,"undefined",10,[35,123,[["exception"," => ",[123,["badmap",44,"undefined"],125]],44,10,["  "],["field"," => ","server"],44,["path"," => ","\"authorization.sources.1\""],44,10,["  "],["reason"," => ","failed_to_check_field"]],125],10]
escript: exception error: #{exception => {badmap,undefined},
                   field => server,path => "authorization.sources.1",
                   reason => failed_to_check_field}
  in function  hocon_tconf:boxit/2 (/emqx/deps/hocon/src/hocon_tconf.erl, line 816)
  in call from hocon_tconf:maybe_mkrich/3 (/emqx/deps/hocon/src/hocon_tconf.erl, line 822)
  in call from hocon_tconf:map_field_maybe_convert/5 (/emqx/deps/hocon/src/hocon_tconf.erl, line 431)
  in call from hocon_tconf:map_one_field/4 (/emqx/deps/hocon/src/hocon_tconf.erl, line 393)
  in call from hocon_tconf:map_fields/4 (/emqx/deps/hocon/src/hocon_tconf.erl, line 372)
  in call from hocon_tconf:do_map_union/4 (/emqx/deps/hocon/src/hocon_tconf.erl, line 611)
  in call from hocon_tconf:map_field/4 (/emqx/deps/hocon/src/hocon_tconf.erl, line 477)
  in call from hocon_tconf:map_one_field/4 (/emqx/deps/hocon/src/hocon_tconf.erl, line 393)
```

```elixir
  iex(15)> [105,110,112,117,116,45,99,111,110,102,105,103,58,10]
  'input-config:\n'
```