### PR TITLE
Fix: schema spec

### DIFF
--- a/include/hocon.hrl
+++ b/include/hocon.hrl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
-%% This header file is inteded for internal use in parser modules.
+%% This header file is intended for internal use in parser modules.
 
 -ifndef(HOCON_HRL).
 -define(HOCON_HRL, true).

--- a/include/hoconsc.hrl
+++ b/include/hoconsc.hrl
@@ -14,16 +14,17 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
-%% This header file is inteded for internal use in schema modules.
-
 -ifndef(HOCONSC_HRL).
 -define(HOCONSC_HRL, true).
+
+-include_lib("typerefl/include/types.hrl").
 
 -define(ARRAY(OfTYpe), {array, OfTYpe}).
 -define(UNION(OfTypes), {union, OfTypes}).
 -define(ENUM(OfSymbols), {enum, OfSymbols}).
 -define(REF(Name), {ref, Name}).
 -define(R_REF(Module, Name), {ref, Module, Name}). % remote ref
+-define(R_REF(NAME), ?R_REF(?MODULE, NAME)).
 -define(IS_TYPEREFL(X), (is_tuple(X) andalso element(1, Type) =:= '$type_refl')).
 
 %% A field having lazy type is not type-checked as a part of its enclosing struct
@@ -33,5 +34,9 @@
 
 %% Map keys are always strings, `Name' is only for documentation
 -define(MAP(Name, Type), {map, Name, Type}).
+
+%% To avoid not import those function. we provide a macro to call them.
+-define(MK(Type), hoconsc:mk(Type)).
+-define(MK(Type, Meta), hoconsc:mk(Type, Meta)).
 
 -endif.

--- a/include/hoconsc.hrl
+++ b/include/hoconsc.hrl
@@ -36,7 +36,7 @@
 -define(MAP(Name, Type), {map, Name, Type}).
 
 %% To avoid not import those function. we provide a macro to call them.
--define(MK(Type), hoconsc:mk(Type)).
--define(MK(Type, Meta), hoconsc:mk(Type, Meta)).
+-define(HOCON(Type), hoconsc:mk(Type)).
+-define(HOCON(Type, Meta), hoconsc:mk(Type, Meta)).
 
 -endif.

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -98,7 +98,7 @@
 -type root_type() :: name() | field().
 -type schema() :: module()
                 | #{ roots := [root_type()]
-                   , fields := #{name() => fields()} | fun((name()) -> fields())
+                   , fields => #{name() => fields()} | fun((name()) -> fields())
                    , translations => #{name() => [translation()]} %% for config mappings
                    , validations => [validation()] %% for config integrity checks
                    , namespace => atom()


### PR DESCRIPTION
1. schema can define as :
```erlang
#{roots => [{"val", hoconsc:map(key, string())}]},
```
the `fields` is not required.

2. add ?R_REF/1 ?MK/1 ?MK/2 macro:
we do a lot of import actions like:
```erlang
-import(hoconsc, [mk/1, mk/2, ref/1, ref/2, array/1, enum/1]).
```
we can use macro to replace the `import`.