### PR TITLE
feat: limit map's key as ^[A-Za-z0-9]+[A-Za-z0-9-_]*$

### DIFF
--- a/include/hoconsc.hrl
+++ b/include/hoconsc.hrl
@@ -32,7 +32,7 @@
 %% the hint type is useful when generating documents
 -define(LAZY(HintType), {lazy, HintType}).
 
-%% Map keys are always strings, `Name' is only for documentation
+%% Map keys are always strings
 -define(MAP(Name, Type), {map, Name, Type}).
 
 %% To avoid not import those function. we provide a macro to call them.


### PR DESCRIPTION
we should limit map's key as `^[A-Za-z0-9]+[A-Za-z0-9-_]*$`.
otherwise :

```yaml
"zones" {
  [20013,22269] {
    "conn_congestion" {"enable_alarm" = true, "min_alarm_sustain_duration" = "1m"}
    "flapping_detect" {
      "ban_time" = "5m"
      "enable" = false
      "max_count" = 15
      "window_time" = "1m"
    }
```