### PR TITLE
fix(schema): no need to check format when converting to plain map

### DIFF
--- a/src/hocon_util.erl
+++ b/src/hocon_util.erl
@@ -59,9 +59,18 @@ real_file_name(F) ->
 
 %% @doc Check if it's a richmap.
 %% A richmap always has a `?HOCON_V' field.
-is_richmap(#{?HOCON_V := _}) -> true;
-is_richmap([H | _]) -> is_richmap(H);
-is_richmap(_) -> false.
+is_richmap(#{?HOCON_V := _}) ->
+    true;
+is_richmap([H | _]) ->
+    is_richmap(H);
+is_richmap(M) when is_map(M) ->
+    %% maybe unboxed value
+    case maps:next(maps:iterator(M)) of
+        {_, V, _} -> is_richmap(V);
+        _ -> false
+    end;
+is_richmap(_) ->
+    false.
 
 %% @doc Convert richmap to plain-map.
 richmap_to_map(RichMap) when is_map(RichMap) ->


### PR DESCRIPTION
The rich-map to plain-map conversion used to rely on the `format`
option. Later is_richmap was introduced, so there is no need to
check option any more.

This commit also fixes a bug in is_richmap:
the boxing layer might be unboxed, so it need to go at least
one level down to check if there is a `$hcVal` field.