### PR TITLE
fix: struct order error if namespace is undefined

### DIFF
--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -300,8 +300,8 @@ find_structs_per_type(_Schema, _Type, Acc, _Stack, _TStack) ->
     Acc.
 
 find_ref(Schema, Name, Acc, Stack, TStack) ->
-    Namespace = hocon_schema:namespace(Schema),
-    Key = {Namespace, Name},
+    Namespace = namespace(Schema),
+    Key = {Namespace, Schema, Name},
     Path = path(Stack),
     Paths =
         case maps:find(Key, Acc) of
@@ -327,7 +327,7 @@ find_structs(Schema) ->
     RootNs = hocon_schema:namespace(Schema),
     {RootNs, RootFields, [
         {Ns, Name, Fields}
-     || {{Ns, Name}, Fields} <- lists:keysort(1, maps:to_list(All))
+     || {{Ns, _Schema, Name}, Fields} <- lists:keysort(1, maps:to_list(All))
     ]}.
 
 unify_roots(Schema) ->

--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -1134,7 +1134,7 @@ check_index_seq(I, [{Index, V} | Rest], Acc) ->
 
 get_invalid_name(Names) ->
     lists:filter(
-        fun(F) ->            
+        fun(F) ->
             nomatch =:=
                 try
                     re:run(F, ?MAP_KEY_RE)

--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -77,6 +77,7 @@
 -define(NULL_BOX, #{?METADATA => #{made_for => null_value}}).
 -define(MAGIC, '$magic_chicken').
 -define(MAGIC_SCHEMA, #{type => ?MAGIC}).
+-define(MAP_KEY_RE, <<"^[A-Za-z0-9]+[A-Za-z0-9-_]*$">>).
 
 %% @doc generates application env from a parsed .conf and a schema module.
 %% For example, one can set the output values by
@@ -529,13 +530,13 @@ map_field(?MAP(_Name, Type), FieldSchema, Value, Opts) ->
                     %% start over
                     do_map(NewFields, Value, Opts, NewSc);
                 InvalidNames ->
-                    Reason =
+                    Context =
                         #{
                             reason => invalid_map_key,
-                            path => path(Opts),
+                            expected_data_type => ?MAP_KEY_RE,
                             got => InvalidNames
                         },
-                    {validation_errs(Opts, Reason), Value}
+                    {validation_errs(Opts, Context), Value}
             end
     end;
 map_field(?R_REF(Module, Ref), FieldSchema, Value, Opts) ->
@@ -1134,7 +1135,7 @@ check_index_seq(I, [{Index, V} | Rest], Acc) ->
 get_invalid_name(Names) ->
     lists:filter(
         fun(F) ->
-            nomatch =:= re:run(F, "^[A-Za-z0-9]+[A-Za-z0-9-_]*$")
+            nomatch =:= re:run(F, ?MAP_KEY_RE)
         end,
         Names
     ).

--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -911,7 +911,7 @@ ensure_obfuscate_sensitive(Opts, Schema, Val) ->
 
 obfuscate(Schema, Value) ->
     case field_schema(Schema, sensitive) of
-        true -> "******";
+        true -> <<"******">>;
         _ -> Value
     end.
 

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -97,7 +97,7 @@ obfuscate_sensitive_values_test() ->
         #{
             <<"bar">> => #{
                 <<"union_with_default">> => dummy,
-                <<"field1">> => "******"
+                <<"field1">> => <<"******">>
             }
         },
         Res1
@@ -111,7 +111,7 @@ obfuscate_sensitive_map_test() ->
     Opts1 = #{obfuscate_sensitive_values => true},
     Conf1 = map_translate_conf(Hocon, Opts1),
     ?assertMatch(
-        #{<<"foo">> := #{<<"max">> := 2, <<"min">> := 1, <<"setting">> := "******"}},
+        #{<<"foo">> := #{<<"max">> := 2, <<"min">> := 1, <<"setting">> := <<"******">>}},
         richmap_to_map(Conf1)
     ),
     ok.
@@ -129,7 +129,7 @@ obfuscate_sensitive_fill_default_test() ->
     Opts1 = #{obfuscate_sensitive_values => true, only_fill_defaults => true},
     Conf1 = map_translate_conf(Hocon, Opts1),
     ?assertMatch(
-        #{<<"foo">> := #{<<"max">> := 2, <<"min">> := 1, <<"setting">> := "******"}},
+        #{<<"foo">> := #{<<"max">> := 2, <<"min">> := 1, <<"setting">> := <<"******">>}},
         richmap_to_map(Conf1)
     ),
 
@@ -143,7 +143,7 @@ obfuscate_sensitive_fill_default_test() ->
     Opts3 = #{obfuscate_sensitive_values => true},
     Conf3 = map_translate_conf(Hocon, Opts3),
     ?assertMatch(
-        #{<<"foo">> := #{<<"max">> := 2, <<"min">> := 1, <<"setting">> := "******"}},
+        #{<<"foo">> := #{<<"max">> := 2, <<"min">> := 1, <<"setting">> := <<"******">>}},
         richmap_to_map(Conf3)
     ),
     ok.
@@ -946,7 +946,7 @@ sensitive_data_obfuscation_test() ->
             receive
                 #{hocon_env_var_name := "EMQX_SECRET", path := Path, value := Value} ->
                     ?assertEqual("secret", Path),
-                    ?assertEqual("******", Value)
+                    ?assertEqual(<<"******">>, Value)
             end
         end,
         envs([{"EMQX_SECRET", "bbb"}])


### PR DESCRIPTION
If the namespace of multiple modules is undefined(the same namespace), the order of structs will be mixed up.