### PR TITLE
refactor: simplify union mismatch error

### DIFF
--- a/src/hocon_schema_example.erl
+++ b/src/hocon_schema_example.erl
@@ -154,7 +154,18 @@ fmt_field(#{type := #{kind := map, name := MapName} = Type} = Field, Path0, Opts
             Indent1 = Indent ++ ?INDENT,
             Opts1 = Opts#{indent => Indent1, comment => true},
             ValFields = fmt_sub_fields(Opts1, Field, Path),
-            [Fix1, Indent1, ?COMMENT, Name, ".", str(MapName), bind_symbol(Opts), ?NL, ValFields, ?NL];
+            [
+                Fix1,
+                Indent1,
+                ?COMMENT,
+                Name,
+                ".",
+                str(MapName),
+                bind_symbol(Opts),
+                ?NL,
+                ValFields,
+                ?NL
+            ];
         false ->
             [Fix1, ?NL]
     end;

--- a/src/hocon_schema_example.erl
+++ b/src/hocon_schema_example.erl
@@ -30,7 +30,6 @@
 -define(PATH, "@path ").
 -define(LINK, "@link ").
 -define(DEFAULT, "@default ").
--define(BIND, " = ").
 
 gen(Schema, undefined) ->
     gen(Schema, "# HOCON Example");
@@ -40,7 +39,13 @@ gen(Schema, #{title := Title, body := Body} = Opts) ->
     File = maps:get(desc_file, Opts, undefined),
     Lang = maps:get(lang, Opts, "en"),
     [Roots | Fields] = hocon_schema_json:gen(Schema, #{desc_file => File, lang => Lang}),
-    FmtOpts = #{tid => new_cache(), indent => "", comment => false, hidden_meta => false},
+    FmtOpts = #{
+        tid => new_cache(),
+        indent => "",
+        comment => false,
+        bind_symbol => bind_symbol(Opts),
+        hidden_meta => false
+    },
     lists:foreach(
         fun(F = #{full_name := Name}) -> insert(FmtOpts, {{full_name, Name}, F}) end, Fields
     ),
@@ -119,7 +124,7 @@ fmt_field(#{type := #{kind := singleton, name := SingleTon}} = Field, Path, Opts
     Name = str(maps:get(name, Field)),
     #{indent := Indent, comment := Comment} = Opts,
     Fix = fmt_fix_header(Field, "singleton", [Name | Path], Opts),
-    [Fix, fmt(Indent, Comment, Name, SingleTon)];
+    [Fix, fmt(Indent, Comment, Name, SingleTon, Opts)];
 fmt_field(#{type := #{kind := enum, symbols := Symbols}} = Field, Path, Opts) ->
     TypeName = ["enum: ", lists:join(" | ", Symbols)],
     Name = str(maps:get(name, Field)),
@@ -149,7 +154,7 @@ fmt_field(#{type := #{kind := map, name := MapName} = Type} = Field, Path0, Opts
             Indent1 = Indent ++ ?INDENT,
             Opts1 = Opts#{indent => Indent1, comment => true},
             ValFields = fmt_sub_fields(Opts1, Field, Path),
-            [Fix1, Indent1, ?COMMENT, Name, ".", str(MapName), ?BIND, ?NL, ValFields, ?NL];
+            [Fix1, Indent1, ?COMMENT, Name, ".", str(MapName), bind_symbol(Opts), ?NL, ValFields, ?NL];
         false ->
             [Fix1, ?NL]
     end;
@@ -164,8 +169,8 @@ fmt_field(#{type := #{kind := array} = Type} = Field, Path0, Opts) ->
     Opts1 = Opts#{indent => Indent1},
     fallback_to_example(Field, Fix1, Indent1, Name, Opts1, Indent, "[]").
 
-fmt(Indent, Comment, Name, Value) ->
-    [Indent, comment(Comment), Name, ?BIND, Value, ?NL].
+fmt(Indent, Comment, Name, Value, Opts) ->
+    [Indent, comment(Comment), Name, bind_symbol(Opts), Value, ?NL].
 
 fallback_to_example(Field, Fix1, Indent1, Name, Opts, Indent, Default) ->
     #{comment := Comment} = Opts,
@@ -177,13 +182,13 @@ fallback_to_example(Field, Fix1, Indent1, Name, Opts, Indent, Default) ->
                     Indent,
                     comment(Comment),
                     Name,
-                    ?BIND,
+                    bind_symbol(Opts),
                     fmt_example(First, Opts),
                     ?NL
                 ]
                 | lists:map(
                     fun(E) ->
-                        [Indent1, ?COMMENT, Name, ?BIND, fmt_example(E, Opts), ?NL]
+                        [Indent1, ?COMMENT, Name, bind_symbol(Opts), fmt_example(E, Opts), ?NL]
                     end,
                     Examples
                 )
@@ -195,8 +200,8 @@ fallback_to_example(Field, Fix1, Indent1, Name, Opts, Indent, Default) ->
                     Default1 -> Default1
                 end,
             case Default2 of
-                "" -> [Fix1, Indent, ?COMMENT, Name, ?BIND, Default2, ?NL];
-                _ -> [Fix1, Indent, comment(Comment), Name, ?BIND, Default2, ?NL]
+                "" -> [Fix1, Indent, ?COMMENT, Name, bind_symbol(Opts), Default2, ?NL];
+                _ -> [Fix1, Indent, comment(Comment), Name, bind_symbol(Opts), Default2, ?NL]
             end
     end.
 
@@ -365,16 +370,16 @@ fmt_examples(Name, #{examples := Examples}, Opts) ->
     lists:map(
         fun(E) ->
             case fmt_example(E, Opts) of
-                [""] -> [Indent, ?COMMENT, Name, ?BIND, ?NL];
-                E1 -> [Indent, comment(Comment), Name, ?BIND, E1, ?NL]
+                [""] -> [Indent, ?COMMENT, Name, bind_symbol(Opts), ?NL];
+                E1 -> [Indent, comment(Comment), Name, bind_symbol(Opts), E1, ?NL]
             end
         end,
         ensure_list(Examples)
     );
 fmt_examples(Name, Field, Opts = #{indent := Indent, comment := Comment}) ->
     case get_default(Field, Opts) of
-        undefined -> [Indent, ?COMMENT, Name, ?BIND, ?NL];
-        Default -> fmt(Indent, Comment, Name, Default)
+        undefined -> [Indent, ?COMMENT, Name, bind_symbol(Opts), ?NL];
+        Default -> fmt(Indent, Comment, Name, Default, Opts)
     end.
 
 ensure_list(L) when is_list(L) -> L;
@@ -454,3 +459,6 @@ insert(#{tid := Tid}, Item) ->
 
 resolve_name({N1, N2}) -> {N1, N2};
 resolve_name(N) -> {N, N}.
+
+bind_symbol(Opts) ->
+    [$\s, maps:get(bind_symbol, Opts, $=), $\s].

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -829,20 +829,20 @@ unknown_fields_test_() ->
     ?GEN_VALIDATION_ERR(
         #{
             reason := unknown_fields,
-            expected_fields := [],
-            unknown_fields := [{<<"name">>, #{line := 1}}]
+            unmatched := none,
+            unknown := <<"name">>
         },
         hocon_tconf:map(demo_schema, M, all)
     ).
 
 expected_fields_not_matched_test_() ->
-    Conf = "\nperson.name=mike",
+    Conf = "\nperson.name=mike\nperson.key=foo\nperson.val=bar\n",
     {ok, M} = hocon:binary(Conf, #{format => richmap}),
     ?GEN_VALIDATION_ERR(
         #{
             reason := unknown_fields,
-            expected_fields := [<<"id">>],
-            unknown_fields := [{<<"name">>, #{line := 2}}]
+            unmatched := <<"id">>,
+            unknown := <<"key,name...">>
         },
         hocon_tconf:map(demo_schema, M, all)
     ).


### PR DESCRIPTION
typical large union type check error: 
none of the members had the input fields.

prior to this change, all expected fields, and received fields are dumped.
this PR changes to only print first 1 or 2 fields and use `...` to replace the 3rd (and more)