### PR TITLE
feat: add field deprecation

### DIFF
--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -38,7 +38,8 @@
     path/1,
     readable_type/1,
     fmt_type/2,
-    fmt_ref/2
+    fmt_ref/2,
+    is_deprecated/1
 ]).
 
 -export([
@@ -119,6 +120,11 @@
         desc => desc(),
         %% hide it from doc generation
         hidden => boolean(),
+        %% Set to {since, Version} to mark field as deprecated.
+        %% deprecated field can not be removed due to compatibility reasons.
+        %% The value will be dropped,
+        %% Deprecated fields are treated as required => {false, recursively}
+        deprecated => {since, binary()} | false,
         %% transparent metadata
         extra => map()
     }.
@@ -506,3 +512,9 @@ fmt_ref(Ns, Name) ->
         true -> Name;
         false -> <<(bin(Ns))/binary, ":", (bin(Name))/binary>>
     end.
+
+%% @doc Return 'true' if the field is marked as deprecated.
+-spec is_deprecated(field_schema()) -> boolean().
+is_deprecated(Schema) ->
+    IsDeprecated = field_schema(Schema, deprecated),
+    IsDeprecated =/= undefined andalso IsDeprecated =/= false.

--- a/src/hocon_schema_json.erl
+++ b/src/hocon_schema_json.erl
@@ -88,17 +88,28 @@ fmt_fields(Ns, [{Name, FieldSchema} | Fields], Opts) ->
     end.
 
 fmt_field(Ns, Name, FieldSchema, Opts) ->
-    Default = hocon_schema:field_schema(FieldSchema, default),
-    L = [
-        {name, bin(Name)},
-        {type, fmt_type(Ns, hocon_schema:field_schema(FieldSchema, type))},
-        {default, fmt_default(Default)},
-        {raw_default, Default},
-        {examples, examples(FieldSchema)},
-        {desc, fmt_desc(hocon_schema:field_schema(FieldSchema, desc), Opts)},
-        {extra, hocon_schema:field_schema(FieldSchema, extra)},
-        {mapping, bin(hocon_schema:field_schema(FieldSchema, mapping))}
-    ],
+    L =
+        case hocon_schema:is_deprecated(FieldSchema) of
+            true ->
+                {since, Vsn} = hocon_schema:field_schema(FieldSchema, deprecated),
+                [
+                    {name, bin(Name)},
+                    {type, fmt_type(Ns, hocon_schema:field_schema(FieldSchema, type))},
+                    {desc, bin(["Deprecated since ", Vsn, "."])}
+                ];
+            false ->
+                Default = hocon_schema:field_schema(FieldSchema, default),
+                [
+                    {name, bin(Name)},
+                    {type, fmt_type(Ns, hocon_schema:field_schema(FieldSchema, type))},
+                    {default, fmt_default(Default)},
+                    {raw_default, Default},
+                    {examples, examples(FieldSchema)},
+                    {desc, fmt_desc(hocon_schema:field_schema(FieldSchema, desc), Opts)},
+                    {extra, hocon_schema:field_schema(FieldSchema, extra)},
+                    {mapping, bin(hocon_schema:field_schema(FieldSchema, mapping))}
+                ]
+        end,
     maps:from_list([{K, V} || {K, V} <- L, V =/= undefined]).
 
 examples(FieldSchema) ->

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -720,8 +720,40 @@ required_test() ->
         #{<<"f2">> => "string", <<"f3">> => 0},
         hocon_tconf:check_plain(ScRequired, #{<<"f2">> => <<"string">>}, #{required => true})
     ),
-
     ok.
+
+deprection_test() ->
+    Sc = #{
+        roots => [
+            {f1, hoconsc:mk(integer())},
+            {f2, hoconsc:mk(string())},
+            {f3, hoconsc:mk(integer(), #{deprecated => {since, "0.1.1"}})}
+        ]
+    },
+    ?assertEqual(
+        #{<<"f2">> => "string"},
+        hocon_tconf:check_plain(
+            Sc,
+            #{<<"f2">> => <<"string">>},
+            #{required => false}
+        )
+    ),
+    ?assertEqual(
+        #{<<"f1">> => 1, <<"f2">> => "string"},
+        hocon_tconf:check_plain(
+            Sc,
+            #{<<"f1">> => 1, <<"f2">> => <<"string">>},
+            #{required => true}
+        )
+    ),
+    ?assertEqual(
+        #{<<"f2">> => "string"},
+        hocon_tconf:check_plain(
+            Sc,
+            #{<<"f2">> => <<"string">>, <<"f3">> => "whatever"},
+            #{required => false}
+        )
+    ).
 
 bad_root_test() ->
     Sc = #{


### PR DESCRIPTION
related: https://github.com/emqx/emqx/issues/8672

The field schema is kept, so the old configuration will continue to be checked OK.
Deprecated field value will be dropped from type-check result,
so the application code should not need to deal with unexpected fields.