### PR TITLE
chore: make scan invalid utf8 error more clear

### DIFF
--- a/src/hocon_token.erl
+++ b/src/hocon_token.erl
@@ -58,7 +58,12 @@ read(Filename) ->
 
 -spec scan(binary() | string(), hocon:ctx()) -> list().
 scan(Input, Ctx) when is_binary(Input) ->
-    scan(unicode_list(Input), Ctx);
+    case unicode_list(Input) of
+        {error, _Ok, Invalid} ->
+            throw({scan_invalid_utf8, Invalid, Ctx});
+        InputList ->
+            scan(InputList, Ctx)
+    end;
 scan(Input, Ctx) when is_list(Input) ->
     case hocon_scanner:string(Input) of
         {ok, Tokens, _EndLine} ->

--- a/test/data/invalid-utf8.conf
+++ b/test/data/invalid-utf8.conf
@@ -1,0 +1,28 @@
+bridges {
+  webhook {
+    test {
+      body = "<!-- Edited by XMLSpy® --> \n<note> \n<to>Tove</to> \n<from>Jani</from> \n<heading>Reminder</heading> \n<body>Don't forget me this weekend!</body> \n</note>"
+      connect_timeout = "11s"
+      direction = "egress"
+      enable = true
+      enable_pipelining = 100
+      headers {"content-type" = "application/json"}
+      max_retries = 3
+      method = "post"
+      pool_size = 9
+      pool_type = "random"
+      request_timeout = "5s"
+      ssl {
+        ciphers = ""
+        depth = 10
+        enable = false
+        reuse_sessions = true
+        secure_renegotiate = true
+        user_lookup_fun = "emqx_tls_psk:lookup"
+        verify = "verify_peer"
+        versions = ["tlsv1.3", "tlsv1.2", "tlsv1.1", "tlsv1"]
+      }
+      url = "http://127.0.0.1:18083"
+    }
+  }
+}

--- a/test/data/unicode-utf8.conf
+++ b/test/data/unicode-utf8.conf
@@ -1,0 +1,6 @@
+# unicode:characters_to_list(<<"®">>, utf8) return {error, _, _}
+# but unicode:characters_to_list(<<"®"/utf8>>, utf8) is ok.
+test {
+  body = "<!-- Edited by XML-XXX® --><note>\n</note>"
+  text = "你我他"
+}

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -881,3 +881,22 @@ unescape_test() ->
         },
         Conf
     ).
+
+unicode_utf8_test() ->
+    {ok, Conf} = hocon:load("./test/data/unicode-utf8.conf"),
+    ?assertEqual(
+        #{
+            <<"test">> =>
+                #{
+                    <<"body">> => <<"<!-- Edited by XML-XXX® --><note>\n</note>"/utf8>>,
+                    <<"text">> => <<"你我他"/utf8>>
+                }
+        },
+        Conf
+    ).
+
+invalid_utf8_test() ->
+    ?assertMatch(
+        {error, {scan_invalid_utf8, _, _}},
+        hocon:load("./test/data/invalid-utf8.conf")
+    ).


### PR DESCRIPTION
Throw more clear logs for scanning invalid utf8.

We can't guarantee that it's all invalid utf8  when the `Input` is from HTTP API.
```erlang
5.0.7-gfdbf8c1c(emqx@127.0.0.1)>jsx:decode(<<"{\"test\":\"® \"}"/utf8>>).
#{<<"test">> => <<"® "/utf8>>}
5.0.7-gfdbf8c1c(emqx@127.0.0.1)2> jsx:decode(<<"{\"test\":\"® \"}">>).
#{<<"test">> => <<239,191,189,32>>}
```