### PR TITLE
1222 feat support reverse convert

### DIFF
--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -152,7 +152,9 @@
 
 -type translation() :: {name(), translationfunc()}.
 -type typefunc() :: fun((_) -> _).
--type translationfunc() :: fun((hocon:config()) -> hocon:config()).
+-type translationfunc() ::
+    fun((hocon:config()) -> hocon:config())
+    | fun((hocon:config(), map()) -> hocon:config()).
 -type validationfun() :: fun((hocon:config()) -> ok | boolean() | {error, term()}).
 -type bin_name() :: binary().
 

--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -721,15 +721,9 @@ match_field_name(Name, ExpectedNames) ->
     lists:partition(fun(N) -> bin(N) =:= bin(Name) end, ExpectedNames).
 
 is_required(Opts, Schema) ->
-    case hocon_schema:is_deprecated(Schema) of
-        true ->
-            %% a deprecated field is never required
-            {false, recursively};
-        false ->
-            case field_schema(Schema, required) of
-                undefined -> maps:get(required, Opts, ?DEFAULT_REQUIRED);
-                Maybe -> Maybe
-            end
+    case field_schema(Schema, required) of
+        undefined -> maps:get(required, Opts, ?DEFAULT_REQUIRED);
+        Maybe -> Maybe
     end.
 
 field_schema(Sc, Key) ->

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -694,7 +694,15 @@ not_empty(_) -> ok.
 validator_crash_test() ->
     Sc = #{roots => [{f1, hoconsc:mk(integer(), #{validator => [fun(_) -> error(always) end]})}]},
     ?VALIDATION_ERR(
-        #{reason := #{exception := {error, always}}},
+        #{reason := #{exception := {error, always}, stacktrace := _}},
+        hocon_tconf:check_plain(Sc, #{<<"f1">> => 11})
+    ),
+    ok.
+
+validator_throw_test() ->
+    Sc = #{roots => [{f1, hoconsc:mk(integer(), #{validator => [fun(_) -> throw(foo) end]})}]},
+    ?VALIDATION_ERR(
+        #{reason := foo},
         hocon_tconf:check_plain(Sc, #{<<"f1">> => 11})
     ),
     ok.

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -747,6 +747,23 @@ required_test() ->
     ),
     ok.
 
+recursive_deprection_test() ->
+    Sc = #{
+        roots => [
+            {f1, hoconsc:mk(integer())},
+            {f2, hoconsc:mk(hoconsc:ref(sub), #{deprecated => {since, "0.1.2"}, reqired => true})}
+        ],
+        fields => #{sub => [{a, string()}, {b, string()}]}
+    },
+    ?assertEqual(
+        #{<<"f1">> => 1},
+        hocon_tconf:check_plain(
+            Sc,
+            #{<<"f1">> => 1},
+            #{required => true}
+        )
+    ).
+
 deprection_test() ->
     Sc = #{
         roots => [


### PR DESCRIPTION
Make parsed results possible to be converted back to serializable format.
Also possible to upgrade older version raw results to newer version.