### PR TITLE
refactor: do not log overriding structs

### DIFF
--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -412,10 +412,8 @@ stringify_line(K, V) when is_list(V) ->
 stringify_line(K, V) ->
     io_lib:format("~s ~w", [K, V]).
 
-log_for_generator(_Level, #{hocon_env_var_name := Var, path := P, value := V}) when is_binary(V) ->
-    ?STDOUT("~s = ~s = ~s", [P, Var, V]);
 log_for_generator(_Level, #{hocon_env_var_name := Var, path := P, value := V}) ->
-    ?STDOUT("~s = ~s = ~0p", [P, Var, V]);
+    log_env_override(Var, P, V);
 log_for_generator(debug, _Args) ->
     ok;
 log_for_generator(info, _Args) ->
@@ -424,6 +422,15 @@ log_for_generator(Level, Msg) when is_binary(Msg) ->
     io:format(standard_error, "[~0p] ~s~n", [Level, Msg]);
 log_for_generator(Level, Args) ->
     io:format(standard_error, "[~0p] ~0p~n", [Level, Args]).
+
+log_env_override(Var, Path, Value) ->
+    ValueStr =
+        case Value of
+            V when is_binary(V) -> V;
+            V when is_map(V) -> "{...}";
+            V -> io_lib:format("~0p", [V])
+        end,
+    ?STDOUT("~s [~s]: ~s", [Var, Path, ValueStr]).
 
 -ifndef(TEST).
 stop_deactivate() ->

--- a/test/hocon_cli_tests.erl
+++ b/test/hocon_cli_tests.erl
@@ -140,6 +140,7 @@ generate_with_env_logging_test() ->
                 ]
             ],
             [
+                {"ZZZ_FOO", "{min: 1, max: 2}"},
                 {"ZZZ_FOO__MIN", "42"},
                 {"ZZZ_FOO__MAX", "43"},
                 {"HOCON_ENV_OVERRIDE_PREFIX", "ZZZ_"}
@@ -148,8 +149,9 @@ generate_with_env_logging_test() ->
         {ok, Stdout} = cuttlefish_test_group_leader:get_output(),
         ?assertEqual(
             [
-                <<"foo.max = ZZZ_FOO__MAX = 43">>,
-                <<"foo.min = ZZZ_FOO__MIN = 42">>
+                <<"ZZZ_FOO [foo]: {...}">>,
+                <<"ZZZ_FOO__MAX [foo.max]: 43">>,
+                <<"ZZZ_FOO__MIN [foo.min]: 42">>
             ],
             lists:sort(
                 binary:split(


### PR DESCRIPTION
# background
In PR #219 the value wrapper for env override metadata is moved to richmap meta data,
as a result, the wrapping struct's meta data is propagated down to the primitive fields.
but one thing was forgotten (not released yet): the override logging started to repeating the same info at different levels.

# change
This PR mutes the struct level logging (because it lacks of `sensitive` information at wrapping object level)
and only log primitive values instead.

# example

before this change:
```
authentication.1 = EMQX_AUTHENTICATION__1 = #{<<“backend”>> => <<“mysql”>>,<<“database”>> => <<“emqx”>>,<<“enable”>> => true,<<“mechanism”>> => <<“password_based”>>,<<“password”>> => <<“emqx”>>,<<“password_hash_algorithm”>> => #{<<“name”>> => <<“sha256">>,<<“salt_position”>> => <<“prefix”>>},<<“query”>> => <<“SELECT password_hash, salt, is_superuser FROM mqtt_us
er WHERE username = ${username} LIMIT 1">>,<<“server”>> => <<“localhost:3306">>,<<“username”>> => <<“emqx”>>}
authentication.1.password = EMQX_AUTHENTICATION__1 = ******
authentication.1.username = EMQX_AUTHENTICATION__1 = emqx
authentication.1.database = EMQX_AUTHENTICATION__1 = emqx
authentication.1.server = EMQX_AUTHENTICATION__1 = localhost:3306
authentication.1.enable = EMQX_AUTHENTICATION__1 = true
authentication.1.query = EMQX_AUTHENTICATION__1 = SELECT password_hash, salt, is_superuser FROM mqtt_user WHERE username = ${username} LIMIT 1
authentication.1.password_hash_algorithm = EMQX_AUTHENTICATION__1 = #{<<“name”>> => <<“sha256">>,<<“salt_position”>> => <<“prefix”>>}
authentication.1.password_hash_algorithm.salt_position = EMQX_AUTHENTICATION__1 = prefix
authentication.1.password_hash_algorithm.name = EMQX_AUTHENTICATION__1 = sha256
authentication.1.backend = EMQX_AUTHENTICATION__1 = mysql
authentication.1.mechanism = EMQX_AUTHENTICATION__1 = password_based
```

after this change:

```
EMQX_AUTHENTICATION__1 [authentication.1]: {...}
EMQX_AUTHENTICATION__1 [authentication.1.password]: ******
EMQX_AUTHENTICATION__1 [authentication.1.username]: emqx
EMQX_AUTHENTICATION__1 [authentication.1.database]: emqx
EMQX_AUTHENTICATION__1 [authentication.1.server]: localhost:3306
EMQX_AUTHENTICATION__1 [authentication.1.enable]: true
EMQX_AUTHENTICATION__1 [authentication.1.query]: SELECT password_hash, salt, is_superuser FROM mqtt_user WHERE username = ${username} LIMIT 1
EMQX_AUTHENTICATION__1 [authentication.1.password_hash_algorithm]: {...}
EMQX_AUTHENTICATION__1 [authentication.1.password_hash_algorithm.salt_position]: prefix
EMQX_AUTHENTICATION__1 [authentication.1.password_hash_algorithm.name]: sha256
EMQX_AUTHENTICATION__1 [authentication.1.backend]: mysql
EMQX_AUTHENTICATION__1 [authentication.1.mechanism]: password_based
```