### PR TITLE
fix: avoid path shadow in union check errors

### DIFF
--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -750,6 +750,24 @@ required_test() ->
     ),
     ok.
 
+required_array_test() ->
+    Sc = #{
+        roots => [
+            {f1, hoconsc:array(hoconsc:union([hoconsc:ref("s1")]))}
+        ],
+        fields => #{
+            "s1" => [
+                {id, hoconsc:mk(integer(), #{required => true})},
+                {name, string()}
+            ]
+        }
+    },
+    ?VALIDATION_ERR(
+        #{reason := required_field, path := "f1.1.id"},
+        hocon_tconf:check_plain(Sc, #{<<"f1">> => [#{<<"name">> => "foo"}]}, #{})
+    ),
+    ok.
+
 recursive_deprecation_test() ->
     Sc = #{
         roots => [


### PR DESCRIPTION
Prior to this change the re-wrapping of validation_error context may cause the real data path to be overwrite.