### PR TITLE
chore: fix type path shadow

### DIFF
--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -755,7 +755,7 @@ do_map_union([], _TypeCheck, PerTypeResult, Opts) ->
     case maps:size(PerTypeResult) of
         1 ->
             [{ReadableType, Err}] = maps:to_list(PerTypeResult),
-            validation_errs(Opts, Err#{matched_type => ReadableType});
+            validation_errs(Opts, ensure_type_path(Err, ReadableType));
         _ ->
             validation_errs(Opts, #{
                 reason => matched_no_union_member,
@@ -1277,6 +1277,14 @@ maybe_hd(Other) -> Other.
 
 readable_type(T) ->
     str(hocon_schema:readable_type(T)).
+
+ensure_type_path(ErrorContext, ReadableType) ->
+    case maps:get(matched_type, ErrorContext, "") of
+        "" ->
+            ErrorContext#{matched_type => ReadableType};
+        SubType ->
+            ErrorContext#{matched_type => ReadableType ++ "/" ++ SubType}
+    end.
 
 -ifndef(TEST).
 assert_fields(_, _) -> ok.

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -768,6 +768,26 @@ required_array_test() ->
     ),
     ok.
 
+%% for union of unions the type path is an important piece of information in the error context
+type_stack_test() ->
+    Sc = #{
+        roots => [
+            {f1, hoconsc:array(hoconsc:union([hoconsc:ref("s1")]))}
+        ],
+        fields => #{
+            "s1" => [{maybe, hoconsc:union([hoconsc:ref("s2")])}],
+            "s2" => [
+                {id, hoconsc:mk(integer(), #{required => true})},
+                {name, string()}
+            ]
+        }
+    },
+    ?VALIDATION_ERR(
+        #{reason := required_field, path := "f1.1.maybe.id", matched_type := "s1/s2"},
+        hocon_tconf:check_plain(Sc, #{<<"f1">> => [#{<<"maybe">> => #{<<"name">> => "foo"}}]}, #{})
+    ),
+    ok.
+
 recursive_deprecation_test() ->
     Sc = #{
         roots => [


### PR DESCRIPTION
prior to this fix, the matched_type error reason from deeper-stack union check is shadowed by uper layer union check