### PR TITLE
feat: add struct (root included) field name aliases

### DIFF
--- a/src/hocon_maps.erl
+++ b/src/hocon_maps.erl
@@ -39,6 +39,7 @@
 -define(EMPTY_MAP, #{}).
 
 -type config() :: hocon:config().
+-type name() :: hocon_schema:name().
 
 %% this can be the opts() from hocon_tconf, but only `atom_key' is relevant
 -type opts() :: #{
@@ -113,7 +114,7 @@ boxit(Value, Box) -> Box#{?HOCON_V => Value}.
 %% @doc Get value from a plain or rich map.
 %% `undefined' is returned if no such value path.
 %% NOTE: always return plain-value.
--spec get([nonempty_string()] | nonempty_string(), config(), term()) -> term().
+-spec get([name()] | name(), config(), term()) -> term().
 get(Path, Config, Default) ->
     case get(Path, Config) of
         undefined -> Default;
@@ -123,13 +124,13 @@ get(Path, Config, Default) ->
 %% @doc get a child node from richmap, return value also a richmap.
 %% `undefined' is returned if no value path.
 %% Key (first arg) can be "foo.bar.baz" or ["foo.bar", "baz"] or ["foo", "bar", "baz"].
--spec deep_get(string() | [string()], config()) -> config() | undefined.
+-spec deep_get(name() | [name()], config()) -> config() | undefined.
 deep_get(Path, Conf) ->
     do_get(hocon_util:split_path(Path), Conf, richmap).
 
 %% @doc Get value from a maybe-rich map.
 %% always return plain-value.
--spec get([nonempty_string()] | nonempty_string(), config()) -> term().
+-spec get([name()] | name(), config()) -> term().
 get(Path, Map) ->
     case is_richmap(Map) of
         true ->

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -133,9 +133,16 @@
         %% The value will be dropped,
         %% Deprecated fields are treated as required => {false, recursively}
         deprecated => {since, binary()} | false,
-        %% other names to reference this field
+        %% Other names to reference this field.
         %% this can be useful when we need to rename some filed names
-        %% while keeping backward compatibility
+        %% while keeping backward compatibility.
+        %% For one struct, no duplication is allowed in the collection of
+        %% all field names and aliases.
+        %% The no-duplication assertion is made when dumping the schema to JSON.
+        %% see `hocon_schema_json'.
+        %% When checking values against the schema, the look up is first
+        %% done with the current field name, if not found, try the aliases
+        %% in the defined order until one is found (i.e. first match wins).
         aliases => [name()],
         %% transparent metadata
         extra => map()

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -34,12 +34,14 @@
     resolve_struct_name/2,
     root_names/1,
     field_schema/2,
-    assert_fields/2,
     path/1,
     readable_type/1,
     fmt_type/2,
     fmt_ref/2,
-    is_deprecated/1
+    is_deprecated/1,
+    aliases/1,
+    name_and_aliases/1,
+    names_and_aliases/1
 ]).
 
 -export([
@@ -131,6 +133,10 @@
         %% The value will be dropped,
         %% Deprecated fields are treated as required => {false, recursively}
         deprecated => {since, binary()} | false,
+        %% other names to reference this field
+        %% this can be useful when we need to rename some filed names
+        %% while keeping backward compatibility
+        aliases => [name()],
         %% transparent metadata
         extra => map()
     }.
@@ -356,12 +362,16 @@ find_ref(Schema, Name, Acc, Stack, TStack) ->
     {RootNs :: name(), RootFields :: [field()], [{Namespace :: name(), Name :: name(), fields()}]}.
 find_structs(Schema) ->
     RootFields = unify_roots(Schema),
-    All = find_structs(Schema, RootFields),
+    ok = assert_no_dot_in_root_names(Schema, RootFields),
+    All = lists:keysort(1, maps:to_list(find_structs(Schema, RootFields))),
     RootNs = hocon_schema:namespace(Schema),
-    {RootNs, RootFields, [
-        {Ns, Name, Fields}
-     || {{Ns, _Schema, Name}, Fields} <- lists:keysort(1, maps:to_list(All))
-    ]}.
+    Unified = lists:map(
+        fun({{Ns, _Schema, Name}, Fields}) ->
+            {Ns, Name, Fields}
+        end,
+        All
+    ),
+    {RootNs, RootFields, Unified}.
 
 unify_roots(Schema) ->
     Roots = ?MODULE:roots(Schema),
@@ -406,32 +416,6 @@ field_schema(FieldSchema, SchemaKey) when is_function(FieldSchema, 1) ->
     FieldSchema(SchemaKey);
 field_schema(FieldSchema, SchemaKey) when is_map(FieldSchema) ->
     maps:get(SchemaKey, FieldSchema, undefined).
-
-%% @doc Assert fields schema sanity.
-assert_fields(EnclosingSchema, []) ->
-    error(#{reason => no_fields_defined, enclosing_schema => EnclosingSchema});
-assert_fields(EnclosingSchema, Fields) ->
-    case assert_unique_field_names(Fields) of
-        ok -> ok;
-        {error, Reason} -> error(Reason#{enclosing_schema => EnclosingSchema})
-    end.
-
-assert_unique_field_names(Fields) ->
-    assert_unique_field_names(Fields, []).
-
-assert_unique_field_names([], _) ->
-    ok;
-assert_unique_field_names([{Name, _} | Rest], Acc) ->
-    BinName = bin(Name),
-    case lists:member(BinName, Acc) of
-        true ->
-            {error, #{
-                reason => duplicated_field_name,
-                name => Name
-            }};
-        false ->
-            assert_unique_field_names(Rest, [BinName | Acc])
-    end.
 
 new_desc_cache(undefined) ->
     #{file => undefined, tab => undefined};
@@ -539,3 +523,52 @@ fmt_ref(Ns, Name) ->
 is_deprecated(Schema) ->
     IsDeprecated = field_schema(Schema, deprecated),
     IsDeprecated =/= undefined andalso IsDeprecated =/= false.
+
+%% @doc Return the aliases in a list.
+-spec aliases(field_schema()) -> [name()].
+aliases(Schema) ->
+    case field_schema(Schema, aliases) of
+        undefined ->
+            [];
+        Names ->
+            lists:map(fun bin/1, Names)
+    end.
+
+%% @doc Return the names and aliases in a list.
+%% The head of the list must be the current name.
+-spec name_and_aliases(field()) -> [name()].
+name_and_aliases({Name, Schema}) ->
+    [bin(Name) | aliases(Schema)].
+
+%% HOCON fields are allowed to have dots in the name,
+%% however we do not support it in the root names.
+%%
+%% This is because the dot will cause root name to be split,
+%% which in turn makes the implementation of hocon_tconf module complicated.
+%%
+%% e.g. if a root name is 'a.b.c', the schema is only defined
+%% for data below `c` level.
+%% `a` and `b` are implicitly single-field roots.
+%%
+%% In this case if a non map value is assigned, such as `a.b=1`,
+%% the check code will crash rather than reporting a useful error reason.
+assert_no_dot_in_root_names(Schema, Roots) ->
+    Names = names_and_aliases(Roots),
+    ok = lists:foreach(fun(Name) -> assert_no_dot(Schema, Name) end, Names).
+
+assert_no_dot(Schema, RootName) ->
+    case hocon_util:split_path(RootName) of
+        [_] ->
+            ok;
+        _ ->
+            error(#{
+                reason => bad_root_name,
+                root_name => RootName,
+                schema => Schema
+            })
+    end.
+
+%% @doc Return all fields' names and aliases in a list.
+-spec names_and_aliases([field()]) -> [name()].
+names_and_aliases(Fields) ->
+    lists:flatmap(fun hocon_schema:name_and_aliases/1, Fields).

--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -14,6 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
+%% tconf: typed-config
 -module(hocon_tconf).
 
 -elvis([{elvis_style, god_modules, disable}]).
@@ -458,6 +459,8 @@ map_fields_cont([{_, FieldSchema} = Field | Fields], Conf0, Acc, Opts) ->
         end,
     Conf1 = put_value(Opts, FieldName, unbox(Opts, FValue), Conf0),
     %% now drop all aliases
+    %% it is allowed to have both old and new names provided in the config
+    %% but the first match wins.
     Conf = maps:without(Aliases, Conf1),
     map_fields(Fields, Conf, FAcc ++ Acc, Opts).
 

--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -294,13 +294,6 @@ map(Schema, Conf0, Roots0, Opts0) ->
     ),
     Conf1 = ensure_format(Conf0, Opts),
     Roots = resolve_root_types(hocon_schema:roots(Schema), Roots0),
-    %% assert
-    lists:foreach(
-        fun({RootName, _RootSc}) ->
-            ok = assert_no_dot(Schema, RootName)
-        end,
-        Roots
-    ),
     Conf2 = filter_by_roots(Opts, Conf1, Roots),
     Conf3 = apply_envs(Schema, Conf2, Opts, Roots),
     {Mapped0, Conf4} = do_map(Roots, Conf3, Opts, ?MAGIC_SCHEMA),
@@ -351,22 +344,23 @@ apply_envs(Schema, Conf0, Opts, Roots) ->
 
 do_apply_envs(_EnvNamespace, _Envs, _Opts, [], Conf) ->
     Conf;
-do_apply_envs(EnvNamespace, Envs, Opts, [{RootName, RootSc} | Roots], Conf) ->
+do_apply_envs(EnvNamespace, Envs, Opts, [{_, RootSc} = Root | Roots], Conf) ->
     ShouldApply =
         case field_schema(RootSc, type) of
             ?LAZY(_) -> maps:get(check_lazy, Opts, false);
             _ -> true
         end,
+    RootNames = name_and_aliases(Root),
     NewConf =
         case ShouldApply of
-            true -> apply_env(EnvNamespace, Envs, RootName, Conf, Opts);
+            true -> apply_env(EnvNamespace, Envs, RootNames, Conf, Opts);
             false -> Conf
         end,
     do_apply_envs(EnvNamespace, Envs, Opts, Roots, NewConf).
 
 %% silently drop unknown data (root level only)
 filter_by_roots(Opts, Conf, Roots) ->
-    Names = lists:map(fun({N, _}) -> bin(N) end, Roots),
+    Names = names_and_aliases(Roots),
     boxit(Opts, maps:with(Names, unbox(Opts, Conf)), Conf).
 
 resolve_root_types(_Roots, []) ->
@@ -380,22 +374,6 @@ resolve_root_types(Roots, [Name | Rest]) ->
             [{Name, hoconsc:ref(Name)} | resolve_root_types(Roots, Rest)]
     end.
 
-%% Assert no dot in root struct name.
-%% This is because the dot will cause root name to be split,
-%% which in turn makes the implementation complicated.
-%%
-%% e.g. if a root name is 'a.b.c', the schema is only defined
-%% for data below `c` level.
-%% `a` and `b` are implicitly single-field roots.
-%%
-%% In this case if a non map value is assigned, such as `a.b=1`,
-%% the check code will crash rather than reporting a useful error reason.
-assert_no_dot(Schema, RootName) ->
-    case split(RootName) of
-        [_] -> ok;
-        _ -> error({bad_root_name, Schema, RootName})
-    end.
-
 str(A) when is_atom(A) -> str(atom_to_binary(A, utf8));
 str(B) when is_binary(B) -> unicode:characters_to_list(B, utf8);
 str(S) when is_list(S) -> S.
@@ -404,7 +382,6 @@ bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
 bin(S) -> unicode:characters_to_binary(S, utf8).
 
 do_map(Fields, Value, Opts, ParentSchema) ->
-    ok = assert_fields(ParentSchema, Fields),
     case unbox(Opts, Value) of
         undefined ->
             case is_required(Opts, ParentSchema) of
@@ -422,7 +399,7 @@ do_map(Fields, Value, Opts, ParentSchema) ->
     end.
 
 do_map2(Fields, Value0, Opts) ->
-    SchemaFieldNames = lists:map(fun({N, _Schema}) -> N end, Fields),
+    SchemaFieldNames = names_and_aliases(Fields),
     DataFields0 = unbox(Opts, Value0),
     DataFields = drop_nulls(Opts, DataFields0),
     Value = boxit(Opts, DataFields, Value0),
@@ -433,18 +410,19 @@ do_map2(Fields, Value0, Opts) ->
 
 map_fields([], Conf, Mapped, _Opts) ->
     {Mapped, Conf};
-map_fields([{FieldName, FieldSchema} | Fields], Conf0, Acc, Opts) ->
+map_fields([{_, FieldSchema} = Field | Fields], Conf0, Acc, Opts) ->
     case hocon_schema:is_deprecated(FieldSchema) of
         true ->
-            Conf = del_value(Opts, bin(FieldName), Conf0),
+            Conf = del_value(Opts, name_and_aliases(Field), Conf0),
             map_fields(Fields, Conf, Acc, Opts);
         false ->
-            map_fields_cont([{FieldName, FieldSchema} | Fields], Conf0, Acc, Opts)
+            map_fields_cont([Field | Fields], Conf0, Acc, Opts)
     end.
 
-map_fields_cont([{FieldName, FieldSchema} | Fields], Conf0, Acc, Opts) ->
+map_fields_cont([{_, FieldSchema} = Field | Fields], Conf0, Acc, Opts) ->
     FieldType = field_schema(FieldSchema, type),
-    FieldValue = get_field(Opts, FieldName, Conf0),
+    [FieldName | Aliases] = name_and_aliases(Field),
+    FieldValue = get_field_value(Opts, [FieldName | Aliases], Conf0),
     NewOpts = push_stack(Opts, FieldName),
     {FAcc, FValue} =
         try
@@ -478,7 +456,9 @@ map_fields_cont([{FieldName, FieldSchema} | Fields], Conf0, Acc, Opts) ->
                 ),
                 erlang:raise(C, Err, St)
         end,
-    Conf = put_value(Opts, FieldName, unbox(Opts, FValue), Conf0),
+    Conf1 = put_value(Opts, FieldName, unbox(Opts, FValue), Conf0),
+    %% now drop all aliases
+    Conf = maps:without(Aliases, Conf1),
     map_fields(Fields, Conf, FAcc ++ Acc, Opts).
 
 map_one_field(FieldType, FieldSchema, FieldValue0, Opts) ->
@@ -870,10 +850,11 @@ check_env(Schema, Roots, Ns, EnvVarName) ->
 
 is_field([], _Name) ->
     false;
-is_field([{FN, FT} | Fields], Name) ->
-    case bin(FN) =:= bin(Name) of
+is_field([{_, FieldSc} = Field | Fields], Name) ->
+    Names = name_and_aliases(Field),
+    case lists:member(bin(Name), Names) of
         true ->
-            Type = hocon_schema:field_schema(FT, type),
+            Type = hocon_schema:field_schema(FieldSc, type),
             {true, Type};
         false ->
             is_field(Fields, Name)
@@ -948,18 +929,18 @@ parse_env(Name, Value, Opts) ->
 
 apply_env(_Ns, [], _RootName, Conf, _Opts) ->
     Conf;
-apply_env(Ns, [{VarName, V} | More], RootName, Conf, Opts) ->
+apply_env(Ns, [{VarName, V} | More], RootNames, Conf, Opts) ->
     %% match [_ | _] here because the name is already validated
     [_ | _] = Path0 = env_name_to_path(Ns, VarName),
     NewConf =
-        case Path0 =/= [] andalso bin(RootName) =:= bin(hd(Path0)) of
+        case Path0 =/= [] andalso lists:member(bin(hd(Path0)), RootNames) of
             true ->
                 Path = lists:flatten(string:join(Path0, ".")),
                 do_apply_env(VarName, V, Path, Conf, Opts);
             false ->
                 Conf
         end,
-    apply_env(Ns, More, RootName, NewConf, Opts).
+    apply_env(Ns, More, RootNames, NewConf, Opts).
 
 do_apply_env(VarName, VarValue, Path, Conf, Opts) ->
     %% It lacks schema info here, so we need to tag the value with 'from_env' meta data
@@ -1043,8 +1024,20 @@ mkrich(Map, Box) when is_map(Map) ->
 mkrich(Val, Box) ->
     boxit(Val, Box).
 
-get_field(#{format := richmap}, Path, Conf) -> hocon_maps:deep_get(Path, Conf);
-get_field(#{format := map}, Path, Conf) -> hocon_maps:get(Path, ensure_plain(Conf)).
+get_field_value(_, [], _Conf) ->
+    undefined;
+get_field_value(Opts, [Path | Rest], Conf) ->
+    case do_get_field_value(Opts, Path, Conf) of
+        undefined ->
+            get_field_value(Opts, Rest, Conf);
+        Value ->
+            Value
+    end.
+
+do_get_field_value(#{format := richmap}, Path, Conf) ->
+    hocon_maps:deep_get(Path, Conf);
+do_get_field_value(#{format := map}, Path, Conf) ->
+    hocon_maps:get(Path, ensure_plain(Conf)).
 
 %% put (maybe deep) value to map/richmap
 %% e.g. "path.to.my.value"
@@ -1055,12 +1048,12 @@ put_value(#{format := richmap} = Opts, Path, V, Conf) ->
 put_value(#{format := map} = Opts, Path, V, Conf) ->
     plain_put(Opts, split(Path), V, Conf).
 
-del_value(Opts, Field, Conf) ->
+del_value(Opts, Names, Conf) ->
     case unbox(Opts, Conf) of
         undefined ->
             Conf;
         V ->
-            boxit(Opts, maps:without([Field], V), Conf)
+            boxit(Opts, maps:without(Names, V), Conf)
     end.
 
 split(Path) -> hocon_util:split_path(Path).
@@ -1310,9 +1303,8 @@ ensure_type_path(Errors, ReadableType) ->
         errors => Errors
     }.
 
--ifndef(TEST).
-assert_fields(_, _) -> ok.
--else.
-assert_fields(ParentSchema, Fields) ->
-    hocon_schema:assert_fields(ParentSchema, Fields).
--endif.
+names_and_aliases(Fields) ->
+    hocon_schema:names_and_aliases(Fields).
+
+name_and_aliases(Field) ->
+    hocon_schema:name_and_aliases(Field).

--- a/test/hocon_schema_aliases_tests.erl
+++ b/test/hocon_schema_aliases_tests.erl
@@ -1,0 +1,97 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(hocon_schema_aliases_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("typerefl/include/types.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
+
+-export([
+    roots/0,
+    fields/1,
+    namespace/0
+]).
+
+namespace() ->
+    aliases.
+
+roots() ->
+    [
+        {"root1", #{
+            aliases => ["old_root1"],
+            type => hoconsc:ref(?MODULE, "root1")
+        }},
+        "root2",
+        {"root3", #{type => boolean(), deprecated => {since, "v0"}, aliases => [<<"old_root3">>]}}
+    ].
+
+fields("root1") ->
+    [{key1, integer()}];
+fields("root2") ->
+    [
+        {key2, #{aliases => [old_key2], type => integer()}},
+        {key3, string()}
+    ].
+
+%% test a root field can be safely renamed
+%% in this case, one of the root level fieds in the test schema ?MODULE.
+%% old_root1 is renamed to root1
+check_root_test() ->
+    ConfText = "{old_root1 = {key1 = 1}, root2 = {key2 = 2, key3 = \"foo\"}}",
+    {ok, Conf} = hocon:binary(ConfText),
+    ?assertEqual(
+        #{
+            <<"root1">> => #{<<"key1">> => 1},
+            <<"root2">> => #{<<"key2">> => 2, <<"key3">> => "foo"}
+        },
+        hocon_tconf:check_plain(?MODULE, Conf)
+    ).
+
+check_field_test() ->
+    ConfText =
+        "{old_root1 = {key1 = 1}, root2 = {old_key2 = 2, key3 = \"foo\"},"
+        "root3 = b, old_root3 = a}",
+    {ok, Conf} = hocon:binary(ConfText),
+    ?assertEqual(
+        #{
+            <<"root1">> => #{<<"key1">> => 1},
+            <<"root2">> => #{<<"key2">> => 2, <<"key3">> => "foo"}
+        },
+        hocon_tconf:check_plain(?MODULE, Conf)
+    ).
+
+check_env_test() ->
+    Fun =
+        fun() ->
+            ConfText = "{root2 = {key3 = \"foo\"}}",
+            {ok, Conf0} = hocon:binary(ConfText),
+            Conf = hocon_tconf:merge_env_overrides(?MODULE, Conf0, all, #{format => map}),
+            ?assertEqual(
+                #{
+                    <<"root1">> => #{<<"key1">> => 42},
+                    <<"root2">> => #{<<"key2">> => 43, <<"key3">> => "foo"}
+                },
+                hocon_tconf:check_plain(?MODULE, Conf)
+            )
+        end,
+    with_envs(Fun, [], envs([{"EMQX_OLD_ROOT1__key1", "42"}, {"EMQX_ROOT2__OLD_KEY2", "43"}])).
+
+with_envs(Fun, Args, Envs) ->
+    hocon_test_lib:with_envs(Fun, Args, Envs).
+
+envs(Envs) ->
+    [{"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"} | Envs].

--- a/test/hocon_schema_json_tests.erl
+++ b/test/hocon_schema_json_tests.erl
@@ -46,7 +46,7 @@ tags_test_() ->
         end}
     ].
 
-duplicated_field_names_test() ->
+unique_field_names_test() ->
     Structs = #{
         foo => [
             {id, hoconsc:mk(integer(), #{default => 12})},
@@ -61,7 +61,27 @@ duplicated_field_names_test() ->
         #{
             duplicated := [<<"id">>],
             path := <<"foo">>,
-            reason := duplicated_field_names
+            reason := duplicated_field_names_and_aliases
+        },
+        gen(Sc)
+    ).
+
+unique_field_name_with_aliases_test() ->
+    Structs = #{
+        foo => [
+            {id, hoconsc:mk(integer(), #{default => 12})},
+            {id2, hoconsc:mk(string(), #{default => 12, aliases => ["id"]})}
+        ]
+    },
+    Sc = #{
+        roots => [{"root", hoconsc:mk(hoconsc:ref(foo), #{required => false})}],
+        fields => Structs
+    },
+    ?assertThrow(
+        #{
+            duplicated := [<<"id">>],
+            path := <<"foo">>,
+            reason := duplicated_field_names_and_aliases
         },
         gen(Sc)
     ).

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -1137,8 +1137,8 @@ no_dot_in_root_name_test() ->
         fields => [{f1, hoconsc:mk(integer())}]
     },
     ?assertError(
-        {bad_root_name, _, "a.b"},
-        hocon_tconf:check_plain(Sc, #{<<"whateverbi">> => 1})
+        #{reason := bad_root_name, root_name := <<"a.b">>},
+        hocon_schema:find_structs(Sc)
     ).
 
 union_of_roots_test() ->


### PR DESCRIPTION
With aliases supported, we can more freely rename fileds. e.g.
if a field is renamed to `new_field`, all we need to do is to keep the old name `field` as an alias in the schema like this:
`{new_filed, #{type => integer(), aliases => [field]}`