### PR TITLE
fix: crash example on union([array[atom()])

### DIFF
--- a/sample-schemas/emqx_schema.erl
+++ b/sample-schemas/emqx_schema.erl
@@ -10,6 +10,7 @@
 -type percent() :: float().
 -type file() :: string().
 -type comma_separated_list() :: list().
+-type comma_separated_atoms() :: [atom()].
 -type bar_separated_list() :: list().
 -type ip_port() :: tuple().
 
@@ -19,18 +20,19 @@
 -typerefl_from_string({bytesize/0, emqx_schema, to_bytesize}).
 -typerefl_from_string({percent/0, emqx_schema, to_percent}).
 -typerefl_from_string({comma_separated_list/0, emqx_schema, to_comma_separated_list}).
+-typerefl_from_string({comma_separated_atoms/0, emqx_schema, to_comma_separated_atoms}).
 -typerefl_from_string({bar_separated_list/0, emqx_schema, to_bar_separated_list}).
 -typerefl_from_string({ip_port/0, emqx_schema, to_ip_port}).
 
 % workaround: prevent being recognized as unused functions
 -export([to_duration/1, to_duration_s/1, to_bytesize/1,
-         to_flag/1, to_percent/1, to_comma_separated_list/1,
+         to_flag/1, to_percent/1, to_comma_separated_list/1, to_comma_separated_atoms/1,
          to_bar_separated_list/1, to_ip_port/1, namespace/0]).
 
 -behaviour(hocon_schema).
 
 -reflect_type([ log_level/0, flag/0, duration/0, duration_s/0,
-                bytesize/0, percent/0, file/0,
+                bytesize/0, percent/0, file/0, comma_separated_atoms/0,
                 comma_separated_list/0, bar_separated_list/0, ip_port/0]).
 
 -export([roots/0, fields/1, translations/0, translation/1, tags/0]).
@@ -1189,6 +1191,9 @@ to_percent(Str) ->
 to_comma_separated_list(Str) ->
     {ok, string:tokens(Str, ", ")}.
 
+to_comma_separated_atoms(Str) ->
+    {ok, lists:map(fun to_atom/1, string:tokens(Str, ", "))}.
+
 to_bar_separated_list(Str) ->
     {ok, string:tokens(Str, "| ")}.
 
@@ -1201,6 +1206,13 @@ to_ip_port(Str) ->
             end;
         _ -> {error, Str}
     end.
+
+to_atom(Atom) when is_atom(Atom) ->
+    Atom;
+to_atom(Str) when is_list(Str) ->
+    list_to_atom(Str);
+to_atom(Bin) when is_binary(Bin) ->
+    binary_to_atom(Bin, utf8).
 
 map_ref(Name) ->
     hoconsc:mk(hoconsc:map("name", hoconsc:ref(Name))).

--- a/src/hocon_schema_example.erl
+++ b/src/hocon_schema_example.erl
@@ -132,7 +132,20 @@ fmt_field(#{type := #{kind := enum, symbols := Symbols}} = Field, Path, Opts) ->
     [Fix, fmt_examples(Name, Field, Opts)];
 fmt_field(#{type := #{kind := union, members := Members0} = Type} = Field, Path0, Opts0) ->
     Name = str(maps:get(name, Field)),
-    Names = lists:map(fun(#{name := N}) -> N end, Members0),
+    Names = lists:map(
+        fun
+            (#{name := N}) ->
+                N;
+            (
+                #{
+                    elements := #{name := N},
+                    kind := array
+                }
+            ) ->
+                <<"[", N/binary, "]">>
+        end,
+        Members0
+    ),
     Path = [Name | Path0],
     TypeStr = ["union() ", lists:join(" | ", Names)],
     Fix = fmt_fix_header(Field, TypeStr, Path, Opts0),

--- a/test/hocon_schema_example_tests.erl
+++ b/test/hocon_schema_example_tests.erl
@@ -66,7 +66,9 @@ fields("example") ->
         {array_key2, hoconsc:array(?R_REF(emqx_schema, "etcd"))},
         {array_key3, hoconsc:array(integer())},
         {array_key4, hoconsc:array(integer())},
-        {array_key5, ?HOCON(hoconsc:array(?R_REF("map_name")), #{examples => [Element]})}
+        {array_key5, ?HOCON(hoconsc:array(?R_REF("map_name")), #{examples => [Element]})},
+        {union_array_key,
+            ?HOCON(hoconsc:union([emqx_schema:comma_separated_atoms(), hoconsc:array(atom())]))}
     ];
 fields("base") ->
     [


### PR DESCRIPTION
Fix:
```
{"init terminating in do_boot",{function_clause,[{hocon_schema_example,'-fmt_field/3-fun-1-',[#{elements=>#{kind=>primitive,name=><<"atom()">>},kind=>array}],[{file,"hocon_schema_example.erl"},{line,139}]},{lists,map,2,[{file,"lists.erl"},{line,1243}]},{lists,map,2,[{file,"lists.erl"},{line,1243}]},{hocon_schema_example,fmt_field,3,[{file,"hocon_schema_example.=ERROR REPORT==== 10-Apr-2023::21:18:12.910199 ===
Error in process <0.9.0> with exit value:
{function_clause,
    [{hocon_schema_example,'-fmt_field/3-fun-1-',
         [#{elements => #{kind => primitive,name => <<"atom()">>},
            kind => array}],
         [{file,"hocon_schema_example.erl"},{line,139}]},
     {lists,map,2,[{file,"lists.erl"},{line,1243}]},
     {lists,map,2,[{file,"lists.erl"},{line,1243}]},
     {hocon_schema_example,fmt_field,3,
         [{file,"hocon_schema_example.erl"},{line,139}]},
     {lists,map,2,[{file,"lists.erl"},{line,1243}]},
     {lists,map,2,[{file,"lists.erl"},{line,1243}]},
     {hocon_schema_example,fmt_field,3,
         [{file,"hocon_schema_example.erl"},{line,96}]},
     {hocon_schema_example,'-gen/2-fun-1-',2,
         [{file,"hocon_schema_example.erl"},{line,58}]}]}

```