### PR TITLE
fix: save utf8 to file garbled

### DIFF
--- a/etc/unescape.conf
+++ b/etc/unescape.conf
@@ -1,5 +1,8 @@
-{
-  sql = "SELECT * FROM \"t/1\"",
-  a = "b=\"1\" "
-  desc = "bar 测试专用 foo"
-}
+a = "b=\"1\" "
+desc = "bar 测试\r\n专\t用 foo\n"
+"sql_laitin1" = "SELECT * FROM t/1"
+"sql_laitin1_with_escape_1" = "SELECT * FROM \"t/1\""
+"sql_laitin1_with_escape_2" = "SELECT * FROM \\\"t/1\\\""
+"sql_unicode_with_escape_1" = "SELECT * FROM \"t/1\" WHERE clientid = \"-测试专用-\""
+"sql_unicode_with_escape_2" = "SELECT * FROM \\\"t/1\\\" WHERE clientid = \"-测试专用-\""
+"sql_unicode_with_escape_3" = "SELECT * FROM \\\"t/1\\\" WHERE clientid = \"-测试\\\n\r\t专用-\""


### PR DESCRIPTION
Before: `hocon_pp:do/2` return unicode as :
```
F = #{<<"a">> => <<"b=\"1\" ">>,
  <<"desc">> =>
      <<98,97,114,32,230,181,139,232,175,149,13,10,228,184,147,
        9,231,148,168,32,102,111,111,10>>,
  <<"sql_laitin1">> => <<"SELECT * FROM t/1">>,
  <<"sql_laitin1_with_escape_1">> =>
      <<"SELECT * FROM \"t/1\"">>,
  <<"sql_laitin1_with_escape_2">> =>
      <<"SELECT * FROM \\\"t/1\\\"">>,
  <<"sql_unicode_with_escape_1">> =>
      <<83,69,76,69,67,84,32,42,32,70,82,79,77,32,34,116,47,49,
        34,32,87,72,69,82,69,32,99,108,105,101,110,116,105,100,
        32,61,32,34,45,230,181,139,232,175,149,228,184,147,231,
        148,168,45,34>>,
  <<"sql_unicode_with_escape_2">> =>
      <<83,69,76,69,67,84,32,42,32,70,82,79,77,32,92,34,116,47,
        49,92,34,32,87,72,69,82,69,32,99,108,105,101,110,116,
        105,100,32,61,32,34,45,230,181,139,232,175,149,228,184,
        147,231,148,168,45,34>>},
file:write_file("test.conf", hocon_pp:do(F, #{})).        
        
```
```
# In file
a = "b=\"1\" "
desc = [98,97,114,32,27979,35797,13,10,19987,9,29992,32,102,111,111,10]
"sql_laitin1" = "SELECT * FROM t/1"
"sql_laitin1_with_escape_1" = "SELECT * FROM \"t/1\""
"sql_laitin1_with_escape_2" = "SELECT * FROM \\\"t/1\\\""
"sql_unicode_with_escape_1" = [83,69,76,69,67,84,32,42,32,70,82,79,77,32,34,116,47,49,34,32,87,72,69,82,69,32,99,108,105,101,110,116,105,100,32,61,32,34,45,27979,35797,19987,29992,45,34]
"sql_unicode_with_escape_2" = [83,69,76,69,67,84,32,42,32,70,82,79,77,32,92,34,116,47,49,92,34,32,87,72,69,82,69,32,99,108,105,101,110,116,105,100,32,61,32,34,45,27979,35797,19987,29992,45,34]
```
After:
```
# in file
a = "b=\"1\" "
desc = "bar 测试\r\n专\t用 foo\n"
"sql_laitin1" = "SELECT * FROM t/1"
"sql_laitin1_with_escape_1" = "SELECT * FROM \"t/1\""
"sql_laitin1_with_escape_2" = "SELECT * FROM \\\"t/1\\\""
"sql_unicode_with_escape_1" = "SELECT * FROM \"t/1\" WHERE clientid = \"-测试专用-\""
"sql_unicode_with_escape_2" = "SELECT * FROM \\"t/1\\" WHERE clientid = \"-测试专用-\""
```