### PR TITLE
fix: detect bad escape sequence

### DIFF
--- a/src/hocon_scanner.xrl
+++ b/src/hocon_scanner.xrl
@@ -80,8 +80,8 @@ Rules.
 {Unquoted}        : {token, maybe_include(TokenChars, TokenLine)}.
 {Integer}         : {token, {integer, TokenLine, list_to_integer(TokenChars)}}.
 {Float}           : {token, {float, TokenLine, to_float(TokenChars)}}.
-{String}          : {token, {string, TokenLine, unquote(TokenChars)}}.
-{MultilineString} : {token, {string, TokenLine, unquote(TokenChars)}}.
+{String}          : {token, {string, TokenLine, unquote(TokenChars, force_escape)}}.
+{MultilineString} : {token, {string, TokenLine, unquote(TokenChars, allow_unescaped)}}.
 {Bytesize}        : {token, {string, TokenLine, TokenChars}}.
 {Percent}         : {token, {string, TokenLine, TokenChars}}.
 {Duration}        : {token, {string, TokenLine, TokenChars}}.
@@ -102,23 +102,36 @@ get_filename_from_required("required(" ++ Filename) ->
 bool("true")  -> true;
 bool("false") -> false.
 
-unquote(Str) ->
-    unescape(strip_surrounded_quotes(Str)).
+unquote(Str, Allow) ->
+    Str1 = strip_surrounded_quotes(Str),
+    try
+        unescape(Str1, Allow)
+    catch
+        throw:unescaped_quote ->
+            throw({unescaped_quote, Str})
+    end.
 
 strip_surrounded_quotes([$" | Rem]) ->
     lists:reverse(strip_surrounded_quotes(lists:reverse(Rem)));
 strip_surrounded_quotes(Str) ->
     Str.
 
-unescape([]) -> [];
-unescape([$\\, $\\ | T]) -> [$\\ | unescape(T)];
-unescape([$\\, $" | T]) -> [$" | unescape(T)];
-unescape([$\\, $n | T]) -> [$\n | unescape(T)];
-unescape([$\\, $t | T]) -> [$\t | unescape(T)];
-unescape([$\\, $r | T]) -> [$\r | unescape(T)];
-unescape([$\\, $b | T]) -> [$\b | unescape(T)];
-unescape([$\\, $f | T]) -> [$\f | unescape(T)];
-unescape([H | T]) -> [H | unescape(T)].
+unescape([], _Allow) ->
+    [];
+unescape([$" | _], force_escape) ->
+    throw(unescaped_quote);
+unescape(S, Allow) ->
+    {H, T} = unesc(S),
+    [H | unescape(T, Allow)].
+
+unesc([$\\, $\\ | T]) -> {$\\, T};
+unesc([$\\, $" | T]) -> {$", T};
+unesc([$\\, $n | T]) -> {$\n, T};
+unesc([$\\, $t | T]) -> {$\t, T};
+unesc([$\\, $r | T]) -> {$\r, T};
+unesc([$\\, $b | T]) -> {$\b, T};
+unesc([$\\, $f | T]) -> {$\f, T};
+unesc([H | T]) -> {H, T}.
 
 maybe_var_ref_name("${?" ++ Name_CR) ->
     [$} | NameRev] = lists:reverse(Name_CR),

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -210,6 +210,58 @@ escape_test_() ->
         ?_assertEqual(
             #{<<"str_b">> => <<" key=\"val\" ">>},
             binary("str_b = \" key=\\\"val\\\" \"")
+        ),
+        %% if there are unescaped quotes between "..."
+        %% it fails the scanner
+        ?_assertMatch(
+            {error, {scan_error, _}},
+            hocon:binary(<<"k=\"a\"cd\"">>)
+        ),
+        %% if there are two backslashes before the " between "..."
+        %% it passes the scanner, but should fail at unescaping
+        ?_assertEqual(
+            {error, {unescaped_quote, "\"a\\\\\"cd\""}},
+            hocon:binary(<<"k=\"a\\\\\"cd\"">>)
+        ),
+        %% " is allowed between """...""" without escaping
+        ?_assertEqual(
+            #{<<"k">> => <<"a\"cd\"x">>},
+            binary(<<"k=\"\"\"a\"cd\"x\"\"\"">>)
+        ),
+        %% " is also allowed between """...""" with escaping
+        ?_assertEqual(
+            #{<<"k">> => <<"a\"cd\"x">>},
+            binary(<<"k=\"\"\"a\\\"cd\\\"x\"\"\"">>)
+        ),
+        %% " immediately beofre """ should be escaped, otherwise scan_error
+        ?_assertMatch(
+            {error, {scan_error, _}},
+            hocon:binary(<<"k=\"\"\"a\"cd\"\"\"\"">>)
+        ),
+        %% " immediately beofre """ should be escaped
+        ?_assertEqual(
+            #{<<"k">> => <<"a\"cd\"">>},
+            binary(<<"k=\"\"\"a\"cd\\\"\"\"\"">>)
+        ),
+        %% \n is parsed as \n between """..."""
+        ?_assertEqual(
+            #{<<"k">> => <<"a\nd">>},
+            binary(<<"k=\"\"\"a\nd\"\"\"">>)
+        ),
+        %% \n between "..." is a scan error
+        ?_assertMatch(
+            {error, {scan_error, _}},
+            hocon:binary(<<"k=\"a\nd\"">>)
+        ),
+        %% \\n parsed as \n between """..."""
+        ?_assertEqual(
+            #{<<"k">> => <<"a\nd">>},
+            binary(<<"k=\"\"\"a\\nd\"\"\"">>)
+        ),
+        %% \\n parsed as \n between "..."
+        ?_assertEqual(
+            #{<<"k">> => <<"a\nd">>},
+            binary(<<"k=\"a\\nd\"">>)
         )
     ].
 


### PR DESCRIPTION
Do not allow unescaped quotes between `"..."`

`key="a"b"` is a syntax error, the valid expression should be `key="a\"b"`
-- this is as expectedd.

However, prior to this change, if we put two backslashes before the `"`, it becomes valid.
i.e. below two files are parsed to the same result:
```
key="a\\"b"
```
and
```
key="a\\\"b"
```

after the fix, `key="a\\"b"` becomes invalid.