### PR TITLE
fix: convert to different union type crash

### DIFF
--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -1031,8 +1031,9 @@ maybe_mkrich(_, undefined, _Box) ->
     undefined;
 maybe_mkrich(#{format := map}, Value, _Box) ->
     Value;
-maybe_mkrich(#{format := richmap}, Value, Box) ->
-    hocon_maps:deep_merge(Box, mkrich(Value, Box)).
+maybe_mkrich(#{format := richmap} = Opts, Value, Box) ->
+    RichValue = unbox(mkrich(Value, Box)),
+    boxit(Opts, RichValue, Box).
 
 mkrich(Arr, Box) when is_list(Arr) ->
     NewArr = [mkrich(I, Box) || I <- Arr],

--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -1031,9 +1031,8 @@ maybe_mkrich(_, undefined, _Box) ->
     undefined;
 maybe_mkrich(#{format := map}, Value, _Box) ->
     Value;
-maybe_mkrich(#{format := richmap} = Opts, Value, Box) ->
-    RichValue = unbox(mkrich(Value, Box)),
-    boxit(Opts, RichValue, Box).
+maybe_mkrich(#{format := richmap}, Value, Box) ->
+    mkrich(Value, Box).
 
 mkrich(Arr, Box) when is_list(Arr) ->
     NewArr = [mkrich(I, Box) || I <- Arr],


### PR DESCRIPTION
1. Define a union type `union([ref(log_file_handler),map(name, ref(log_file_handler))]`
2. Convert `ref(log_file_handler)` to `map(name, ref(log_file_handler))`
3. Crash

```
**throw:{#{roots =>
       [{f1,#{converter => #Fun<hocon_tconf_tests.57.87224844>,
              type =>
                  {union,[{ref,hocon_tconf_tests,bar},
                          {map,name,{ref,hocon_tconf_tests,bar}}]}}}]},
 [#{kind => validation_error,
    mismatches =>
        #{"bar" =>
              #{kind => validation_error,path => "f1",
                reason => unknown_fields,unknown => "default",
                unmatched => "host,union_with_default"},
          "name" =>
              #{kind => validation_error,
                location => #{line => 1},
                path => "f1.field1",reason => bad_value_for_struct,
                value => <<"foo1">>}},
    path => "f1",reason => matched_no_union_member}]}
  output:<<"">>
```
More detail see `test/hocon_tconf_tests.erl`