### PR TITLE
fix: bad pp unicode map keys

### DIFF
--- a/src/hocon_pp.erl
+++ b/src/hocon_pp.erl
@@ -152,10 +152,13 @@ gen_map_field(K, V, Opts, NL) ->
 
 %% maybe quote key
 maybe_quote(K) when is_atom(K) -> atom_to_list(K);
-maybe_quote(K) ->
-    case re:run(K, "[^A-Za-z_]") of
-        nomatch -> K;
-        _ -> io_lib:format("~0p", [unicode:characters_to_list(K, utf8)])
+maybe_quote(K0) ->
+    case re:run(K0, "[^A-Za-z_]") of
+        nomatch ->
+            K0;
+        _ ->
+            K1 = unicode:characters_to_list(K0, utf8),
+            <<"\"", (format_escape_sequences(K1))/binary, "\"">>
     end.
 
 bin(IoData) ->

--- a/test/hocon_pp_tests.erl
+++ b/test/hocon_pp_tests.erl
@@ -152,5 +152,10 @@ utf8_test() ->
     ?assertThrow({invalid_utf8, _}, hocon_pp:do(InvalidUtf8, #{})),
     Utf8 = #{<<"test">> => <<"测试-专用"/utf8>>},
     PP = hocon_pp:do(Utf8, #{}),
-    {ok, Conf2} = hocon:binary(PP),
-    ?assertEqual(Utf8, Conf2).
+    {ok, Conf} = hocon:binary(PP),
+    ?assertEqual(Utf8, Conf),
+    %% support utf8 key
+    Utf81 = #{<<"测试-test-专用"/utf8>> => <<"测试-专用"/utf8>>},
+    PP1 = hocon_pp:do(Utf81, #{}),
+    {ok, Conf1} = hocon:binary(PP1),
+    ?assertEqual(Utf81, Conf1).


### PR DESCRIPTION
fixes: Part of https://emqx.atlassian.net/browse/EMQX-9546
https://emqx.atlassian.net/browse/EMQX-9999

> file:write_file("test.conf",hocon_pp:do(#{<<"test">> => #{<<"测试"/utf8>> => 1}},#{})).

before: 
```
# test.conf
test {[27979,35797] = 1}
```
after:
```
# test.conf
test {"测试" = 1}
```