### PR TITLE
fix(hocon_token): fix scan error message format

### DIFF
--- a/src/hocon_token.erl
+++ b/src/hocon_token.erl
@@ -289,25 +289,16 @@ parse_error(Line, ErrorInfo, Ctx) ->
     throw({parse_error, format_error(Line, ErrorInfo, Ctx)}).
 
 format_error(Line, ErrorInfo, #{filename := [undefined]}) ->
-    unicode_bin(
-        [
-            ErrorInfo,
-            io_lib:format(
-                " line_number ~w",
-                [Line]
-            )
-        ]
-    );
+    #{
+        reason => lists:flatten([ErrorInfo]),
+        line => Line
+    };
 format_error(Line, ErrorInfo, Ctx) ->
-    unicode_bin(
-        [
-            ErrorInfo,
-            io_lib:format(
-                " line_number ~w in_file ~s",
-                [Line, hd(hocon_util:get_stack(filename, Ctx))]
-            )
-        ]
-    ).
+    #{
+        reason => lists:flatten([ErrorInfo]),
+        line => Line,
+        file => hd(hocon_util:get_stack(filename, Ctx))
+    }.
 
 unicode_bin(L) -> unicode:characters_to_binary(L, utf8).
 unicode_list(B) -> unicode:characters_to_list(B, utf8).

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -602,8 +602,8 @@ concat_error_binary_test_() ->
     ].
 
 parse_sytax_error_test() ->
-    {error, {parse_error, Txt}} = hocon:binary("a=xyz, b=true${a}"),
-    ?assertEqual(Txt, <<"syntax error before: <<\"a\">> line_number 1">>).
+    {error, {parse_error, Error}} = hocon:binary("a=xyz, b=true${a}"),
+    ?assertEqual(Error, #{line => 1, reason => "syntax error before: <<\"a\">>"}).
 
 concat_error_file_test_() ->
     [


### PR DESCRIPTION
prior to this change, the scan error is formated as a utf8 binary string, this caused some unreadable error messages if the error is not formated to console using ~ts.

this commit changes the error report to a map, in which, at least the line number and file paht/name are universally printable --- this is usually enough to find the error.