### PR TITLE
feat: transform atom to binary if serializable=true

### DIFF
--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -657,7 +657,7 @@ map_field(Type, Schema, Value0, Opts) ->
 eval_builtin_converter(PlainValue, Type, Opts) ->
     case is_make_serializable(Opts) of
         true ->
-            ensure_bin_str(PlainValue);
+            ensure_serializable(PlainValue);
         false ->
             hocon_schema_builtin:convert(PlainValue, Type)
     end.
@@ -1263,12 +1263,16 @@ eval_arity1_converter(F, V, Opts) ->
 obfuscate_sensitive_values(#{obfuscate_sensitive_values := true}) -> true;
 obfuscate_sensitive_values(_) -> false.
 
-ensure_bin_str(Value) when is_list(Value) ->
+ensure_serializable(undefined) ->
+    undefined;
+ensure_serializable(Boolean) when is_boolean(Boolean) -> Boolean;
+ensure_serializable(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8);
+ensure_serializable(Value) when is_list(Value) ->
     case io_lib:printable_unicode_list(Value) of
         true -> unicode:characters_to_binary(Value, utf8);
         false -> Value
     end;
-ensure_bin_str(Value) ->
+ensure_serializable(Value) ->
     Value.
 
 check_indexed_array(List) ->

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -93,6 +93,17 @@ default_value_test() ->
             }
         },
         Res
+    ),
+    %% check foo and dummy is binary.
+    ?assertEqual(
+        #{
+            <<"bar">> =>
+                #{
+                    <<"field1">> => <<"foo">>,
+                    <<"union_with_default">> => <<"dummy">>
+                }
+        },
+        hocon_tconf:make_serializable(?MODULE, Res, #{})
     ).
 
 obfuscate_sensitive_values_test() ->
@@ -167,7 +178,7 @@ nest_ref_fill_default_test() ->
             #{
                 <<"perf">> =>
                     #{
-                        <<"route_lock_type">> => key,
+                        <<"route_lock_type">> => <<"key">>,
                         <<"trie_compaction">> => true
                     },
                 <<"route_batch_clean">> => false


### PR DESCRIPTION
```erlang
1> Sc = #{roots => [{"discovery_strategy", hoconsc:mk(hoconsc:enum([manual, static, dns, etcd, k8s, mcast]),#{default => manual })}]}.
#{roots =>
      [{"discovery_strategy",
        #{default => manual,
          type => {enum,[manual,static,dns,etcd,k8s,mcast]}}}]}

% The `discovery_strategy` has  a atom value(`manual`) if fallback to default.
2> hocon_tconf:make_serializable(Sc, #{}, #{}).
#{<<"discovery_strategy">> => manual}

% Read from hocon file will get a binary value <<"manual">>.
3> {ok, Map} =hocon:binary(<<"discovery_strategy = manual">>).
{ok, #{<<"discovery_strategy">> => <<"manual">>}}
4> hocon_tconf:make_serializable(Sc, Map, #{}).
#{<<"discovery_strategy">> => <<"manual">>}
```
So we have standardized on "binary" value.
PS: We can't get atom value from `hocon:binary/1` map's value either.

After the PR, always return binary value.
```erlang
2> hocon_tconf:make_serializable(Sc, #{}, #{}).
#{<<"discovery_strategy">> => <<"manual">>}

3> {ok, Map} =hocon:binary(<<"discovery_strategy = manual">>).
{ok, #{<<"discovery_strategy">> => <<"manual">>}}
4> hocon_tconf:make_serializable(Sc, Map, #{}).
#{<<"discovery_strategy">> => <<"manual">>}
```
