### PR TITLE
fix(pp): ensure generic atoms printed as strings

### DIFF
--- a/etc/null.conf
+++ b/etc/null.conf
@@ -1,0 +1,6 @@
+cluster {
+  name = ""
+  discovery = null
+}
+
+node.cookie = null

--- a/src/hocon_pp.erl
+++ b/src/hocon_pp.erl
@@ -82,9 +82,14 @@ gen([], _Opts) ->
     <<"[]">>;
 gen(<<>>, _Opts) ->
     <<"\"\"">>;
+gen('', _Opts) ->
+    <<"\"\"">>;
+gen(null, _Opts) ->
+    <<"null">>;
 gen(I, _Opts) when is_integer(I) -> integer_to_binary(I);
 gen(F, _Opts) when is_float(F) -> float_to_binary(F, [{decimals, 6}, compact]);
-gen(A, _Opts) when is_atom(A) -> atom_to_binary(A, utf8);
+gen(B, _Opts) when is_boolean(B) -> atom_to_binary(B);
+gen(A, Opts) when is_atom(A) -> gen(atom_to_list(A), Opts);
 gen(Bin, Opts) when is_binary(Bin) ->
     Str = unicode:characters_to_list(Bin, utf8),
     case is_list(Str) of

--- a/test/hocon_pp_tests.erl
+++ b/test/hocon_pp_tests.erl
@@ -23,14 +23,22 @@ atom_test() ->
     RawConf =
         #{
             atom_key => #{atom_key => atom_value},
-            <<"binary_key">> => #{atom_key => <<"binary_value">>}
+            <<"binary_key">> => #{
+                atom_key1 => <<"binary_value">>,
+                atom_key2 => '42wierd_atom_value',
+                atom_key3 => ''
+            }
         },
     PP = hocon_pp:do(RawConf, #{}),
     {ok, RawConf2} = hocon:binary(iolist_to_binary(PP)),
     ?assertEqual(
         #{
             <<"atom_key">> => #{<<"atom_key">> => <<"atom_value">>},
-            <<"binary_key">> => #{<<"atom_key">> => <<"binary_value">>}
+            <<"binary_key">> => #{
+                <<"atom_key1">> => <<"binary_value">>,
+                <<"atom_key2">> => <<"42wierd_atom_value">>,
+                <<"atom_key3">> => <<"">>
+            }
         },
         RawConf2
     ).
@@ -38,6 +46,7 @@ atom_test() ->
 pp_test_() ->
     [
         {"emqx.conf", do_fun("etc/emqx.conf")},
+        {"null.conf", do_fun("etc/null.conf")},
         {"unicode.conf", do_fun("etc/unicode.conf")},
         {"unescape.conf", do_fun("etc/unescape.conf")}
     ].


### PR DESCRIPTION
Before this fix, `hocon_pp:do(#{val => '12345'}, #{})` would produce invalid HOCON document.