### PR TITLE
fix: honor hocon spec for quote string

### DIFF
--- a/test/hocon_pp_tests.erl
+++ b/test/hocon_pp_tests.erl
@@ -98,6 +98,29 @@ pp_quote_test() ->
         <<"d_dfdk2f = \"466f5fbb86b19f14f921784539870228\"\n">>
     ),
     Fun(#{<<"$d_dfdk2f">> => <<"12">>}, <<"\"$d_dfdk2f\" = \"12\"\n">>),
+
+    %% backslash
+    Fun(#{<<"test_backslash">> => <<"\\emqx">>}, <<"test_backslash = \"\\\\emqx\"\n">>),
+    Fun(#{<<"test_backslash">> => <<"emqx\\emqx">>}, <<"test_backslash = \"emqx\\\\emqx\"\n">>),
+    Fun(#{<<"test_backslash">> => <<"emqx\\">>}, <<"test_backslash = \"emqx\\\\\"\n">>),
+
+    %% quote
+    Fun(#{<<"test_quote">> => <<"\"emqx">>}, <<"test_quote = \"\\\"emqx\"\n">>),
+    Fun(#{<<"test_quote">> => <<"emqx\"emqx">>}, <<"test_quote = \"emqx\\\"emqx\"\n">>),
+    Fun(#{<<"test_quote">> => <<"emqx\"">>}, <<"test_quote = \"emqx\\\"\"\n">>),
+
+    %% '${}[]:=,+#`^?!@*& ' should quote
+    lists:foreach(
+        fun(Char) ->
+            Header = list_to_binary([Char | "emqx"]),
+            Tail = list_to_binary("emqx" ++ [Char]),
+            Middle = <<Tail/binary, "emqx">>,
+            Fun(#{<<"test_key">> => Header}, <<"test_key = \"", Header/binary, "\"\n">>),
+            Fun(#{<<"test_key">> => Tail}, <<"test_key = \"", Tail/binary, "\"\n">>),
+            Fun(#{<<"test_key">> => Middle}, <<"test_key = \"", Middle/binary, "\"\n">>)
+        end,
+        "'${}[]:=,+#`^?!@*& "
+    ),
     ok.
 
 load_file_pp_test() ->


### PR DESCRIPTION
https://github.com/lightbend/config/blob/main/HOCON.md#unquoted-strings
Fix: https://emqx.atlassian.net/browse/EMQX-10294

Unquoted strings

> A sequence of characters outside of a quoted string is a string value if:
> 
> it does not contain "forbidden characters": '$', '"', '{', '}', '[', ']', ':', '=', ',', '+', '#', '`', '^', '?', '!', '@', '*', '&', '' (backslash), or whitespace.
> it does not contain the two-character string "//" (which starts a comment)
> its initial characters do not parse as true, false, null, or a number.
> Unquoted strings are used literally, they do not support any kind of escaping. Quoted strings may always be used as an alternative when you need to write a character that is not permitted in an unquoted string.
> 
> truefoo parses as the boolean token true followed by the unquoted string foo. However, footrue parses as the unquoted string footrue. Similarly, 10.0bar is the number 10.0 then the unquoted string bar but bar10.0 is the unquoted string bar10.0. (In practice, this distinction doesn't matter much because of value concatenation; see later section.)
> 
> In general, once an unquoted string begins, it continues until a forbidden character or the two-character string "//" is encountered. Embedded (non-initial) booleans, nulls, and numbers are not recognized as such, they are part of the string.
> 
> An unquoted string may not begin with the digits 0-9 or with a hyphen (-, 0x002D) because those are valid characters to begin a JSON number. The initial number character, plus any valid-in-JSON number characters that follow it, must be parsed as a number value. Again, these characters are not special inside an unquoted string; they only trigger number parsing if they appear initially.
> 
> Note that quoted JSON strings may not contain control characters (control characters include some whitespace characters, such as newline). This rule is from the JSON spec. However, unquoted strings have no restriction on control characters, other than the ones listed as "forbidden characters" above.
> 
> Some of the "forbidden characters" are forbidden because they already have meaning in JSON or HOCON, others are essentially reserved keywords to allow future extensions to this spec.