### PR TITLE
fix: updates return type for `desc` callback

### DIFF
--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -67,7 +67,7 @@
 -callback translations() -> [name()].
 -callback translation(name()) -> [translation()].
 -callback validations() -> [validation()].
--callback desc(name()) -> iodata() | undefined.
+-callback desc(name()) -> desc() | undefined.
 -callback tags() -> [tag()].
 
 -optional_callbacks([


### PR DESCRIPTION
Fix return type for `desc` callback