### PR TITLE
feat: add unsafe atom conversion to `hocon_tconf:check_plain`

### DIFF
--- a/src/hocon_maps.erl
+++ b/src/hocon_maps.erl
@@ -96,6 +96,8 @@ maybe_atom(#{atom_key := true}, Name) when is_binary(Name) ->
         _:_ ->
             error({non_existing_atom, Name})
     end;
+maybe_atom(#{atom_key := {true, unsafe}}, Name) when is_binary(Name) ->
+    binary_to_atom(Name, utf8);
 maybe_atom(_Opts, Name) ->
     Name.
 


### PR DESCRIPTION
By using `hocon_tconf:check_plain(Schema, Map, #{atom_key => {true, unsafe}})`, fields and `hoconsc:map` keys are converted to atoms unsafely, while keys in `map()` and their nested values therein are kept as binaries.