### PR TITLE
fix: avoid concatenating objects on different lines

### DIFF
--- a/src/hocon_token.erl
+++ b/src/hocon_token.erl
@@ -126,6 +126,12 @@ trans_splice_end([{include, _File} = V | Tokens], Seq, Acc) ->
 trans_splice_end([{T, _Line} = V | Tokens], Seq, Acc) when T =:= ',' ->
     NewAcc = [V | do_trans_splice_end(Seq) ++ Acc],
     trans_splice_end(Tokens, [], NewAcc);
+trans_splice_end([{'}', Line1} = V1, {'{', Line2} = V2 | Tokens], Seq, Acc) when
+    Line1 /= Line2
+->
+    %% Inject virtual comma to avoid concatenating objects that are separated by newlines,
+    %% as we don't track newline tokens here.
+    trans_splice_end([V1, {',', Line1}, V2 | Tokens], Seq, Acc);
 trans_splice_end([{T, _Line} = V | Tokens], Seq, Acc) when
     T =:= '}' orelse
         T =:= ']'

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -961,3 +961,44 @@ empty_map_test_() ->
         ?_assertEqual({ok, #{<<"a">> => #{}}}, hocon:binary("a={}")),
         ?_assertEqual({ok, #{<<"a">> => #{<<"b">> => #{}}}}, hocon:binary("a:{b:{}}"))
     ].
+
+adjacent_maps_test_() ->
+    [
+        ?_assertEqual(
+            {ok, #{<<"x">> => [#{<<"a">> => 1}, #{<<"b">> => 2}]}},
+            hocon:binary(<<"x = [\n{a = 1}\n{b = 2}\n]\n">>)
+        ),
+        ?_assertEqual(
+            {ok, #{<<"x">> => [#{<<"a">> => 1, <<"aa">> => 11}, #{<<"b">> => 2}]}},
+            hocon:binary(<<"x = [\n{a = 1, aa = 11}\n{b = 2}\n]\n">>)
+        ),
+        ?_assertEqual(
+            {ok, #{<<"x">> => [#{<<"a">> => 1, <<"aa">> => 11}, #{<<"b">> => 2}]}},
+            hocon:binary(<<"x = [\n{a = 1, aa = 11}, {b = 2}\n]\n">>)
+        ),
+        ?_assertEqual(
+            {ok, #{<<"x">> => [#{<<"a">> => 1, <<"aa">> => 11}, #{<<"b">> => 2}]}},
+            hocon:binary(<<"x = [\n{a = 1, aa = 11}, {b = 2}\n]\n">>)
+        ),
+        ?_assertEqual(
+            {ok, #{<<"x">> => [1, #{<<"a">> => 1, <<"b">> => 2}, #{<<"c">> => 3}, 4]}},
+            hocon:binary(<<"x = [\n1, {a = 1} {b = 2}\n{c = 3}, 4\n]\n">>)
+        ),
+        ?_assertEqual(
+            {ok, #{<<"x">> => [1, #{<<"a">> => 1, <<"b">> => 2}, #{<<"c">> => 3}, 4]}},
+            hocon:binary(<<"x = [\n1, {\n a = 1} {\n b = 2}\n{c = 3}, 4\n]\n">>)
+        ),
+        ?_assertEqual(
+            {ok, #{<<"x">> => [1, #{<<"a">> => 1, <<"b">> => 2}, #{<<"c">> => 3}, 4]}},
+            hocon:binary(<<"x = [\n1, {\n a = 1\n} {\n b = 2}\n{c = 3}, 4\n]\n">>)
+        ),
+        ?_assertEqual(
+            {ok, #{<<"x">> => [1, #{<<"a">> => 1}, #{<<"b">> => 2}, #{<<"c">> => 3}, 4]}},
+            hocon:binary(<<"x = [\n1, {\n a = 1\n}\n {\n b = 2}\n{c = 3}, 4\n]\n">>)
+        ),
+        {"newlines act as commas",
+            ?_assertEqual(
+                {ok, #{<<"x">> => [#{<<"a">> => 1}, #{<<"b">> => 2}]}},
+                hocon:binary(<<"x = [{a = 1}\n {b = 2}]">>)
+            )}
+    ].


### PR DESCRIPTION
According to [HOCON Concatenation](https://github.com/lightbend/config#concatenation), we shouldn't concatenate objects that are separated by newlines.