### PR TITLE
fix(schema): Allow unresolvable struct desc

### DIFF
--- a/sample-schemas/demo_schema6.erl
+++ b/sample-schemas/demo_schema6.erl
@@ -4,7 +4,7 @@
 
 -behaviour(hocon_schema).
 
--export([namespace/0, roots/0, fields/1]).
+-export([namespace/0, roots/0, fields/1, desc/1]).
 
 namespace() -> undefined.
 
@@ -18,3 +18,8 @@ fields(foo) ->
     ];
 fields(im_hidden) ->
     [{i_should_be_hidden, integer()}].
+
+desc(foo) ->
+    {foo, invalid};
+desc(_) ->
+    undefined.

--- a/test/hocon_schema_json_tests.erl
+++ b/test/hocon_schema_json_tests.erl
@@ -131,7 +131,7 @@ hidden_structs1_test() ->
     ).
 
 hidden_structs2_test() ->
-    Json = gen(demo_schema6),
+    Json = gen(demo_schema6, #{desc_resolver => fun(_) -> undefined end}),
     ?assertMatch(
         [
             #{
@@ -147,5 +147,19 @@ hidden_structs2_test() ->
         Json
     ).
 
+hidden_structs3_test() ->
+    ?assertThrow(
+        #{reason := bad_desc_resolution, resolution := invalid},
+        gen(demo_schema6, #{desc_resolver => fun(_) -> invalid end})
+    ).
+
+bad_desc_test() ->
+    Throw = fun(_) -> throw({foo, ?FUNCTION_NAME}) end,
+    ?assertThrow({foo, ?FUNCTION_NAME}, Throw(a)),
+    ?assertThrow({foo, ?FUNCTION_NAME}, gen(demo_schema6, #{desc_resolver => Throw})).
+
 gen(Schema) ->
     hocon_schema_json:gen(Schema).
+
+gen(Schema, Opts) ->
+    hocon_schema_json:gen(Schema, Opts).


### PR DESCRIPTION
In hocon schema, field desc is allowed to be missing and unresolvable. Prior to this fix, the struct desc is allowed to be missing but not unresolvable.
For example, if the desc is resoved from {desc, reference}, but failed. i.e. returned 'undefined', this atom is used in the iodata output which then causes 'badarg' error when getting serialized