### PR TITLE
fix: validate map field name length before attempting to convert to atoms

### DIFF
--- a/src/hocon_maps.erl
+++ b/src/hocon_maps.erl
@@ -50,6 +50,10 @@
 
 -type flatten_opts() :: #{rich_value => boolean()}.
 
+-elvis([
+    {elvis_style, atom_naming_convention, #{regex => "^([a-z][a-z0-9]*_?)([a-z0-9]*_?)*(_SUITE)?$"}}
+]).
+
 %% @doc put unboxed value to the richmap box
 %% this function is called places where there is no boxing context
 %% so it has to accept unboxed value.
@@ -89,6 +93,8 @@ update_map_field(Opts, Map, FieldName, GoDeep) ->
     Map1 = maps:without([FieldName], Map),
     Map1#{maybe_atom(Opts, FieldName) => FieldV}.
 
+maybe_atom(#{atom_key := true}, Name) when is_binary(Name), size(Name) > 255 ->
+    error({name_longer_than_255_bytes, Name});
 maybe_atom(#{atom_key := true}, Name) when is_binary(Name) ->
     try
         binary_to_existing_atom(Name, utf8)
@@ -96,6 +102,8 @@ maybe_atom(#{atom_key := true}, Name) when is_binary(Name) ->
         _:_ ->
             error({non_existing_atom, Name})
     end;
+maybe_atom(#{atom_key := {true, unsafe}}, Name) when is_binary(Name), size(Name) > 255 ->
+    error({name_longer_than_255_bytes, Name});
 maybe_atom(#{atom_key := {true, unsafe}}, Name) when is_binary(Name) ->
     binary_to_atom(Name, utf8);
 maybe_atom(_Opts, Name) ->

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -2436,6 +2436,60 @@ map_atom_keys_test_() ->
                     },
                     V
                 )
+            end)},
+        {"key length > 255 bytes (atom_key = true)",
+            ?_test(begin
+                BadKeyStr = lists:duplicate(256, $a),
+                BadKey = list_to_binary(BadKeyStr),
+                BadMap = #{<<"root">> => #{BadKey => #{<<"foo">> => #{}}}},
+                ?assertThrow(
+                    {_, [
+                        #{
+                            kind := validation_error,
+                            got := [BadKeyStr],
+                            reason := invalid_map_key
+                        }
+                    ]},
+                    hocon_tconf:check_plain(
+                        Sc,
+                        BadMap,
+                        #{atom_key => true}
+                    )
+                )
+            end)},
+        {"key length > 255 bytes (atom_key = {true, unsafe})",
+            ?_test(begin
+                BadKeyStr = lists:duplicate(256, $a),
+                BadKey = list_to_binary(BadKeyStr),
+                BadMap = #{<<"root">> => #{BadKey => #{<<"foo">> => #{}}}},
+                ?assertThrow(
+                    {_, [
+                        #{
+                            kind := validation_error,
+                            got := [BadKeyStr],
+                            reason := invalid_map_key
+                        }
+                    ]},
+                    hocon_tconf:check_plain(
+                        Sc,
+                        BadMap,
+                        #{atom_key => {true, unsafe}}
+                    )
+                )
+            end)},
+        {"key length > 255 bytes (atom_key = false)",
+            ?_test(begin
+                BadKeyStr = lists:duplicate(256, $a),
+                BadKey = list_to_binary(BadKeyStr),
+                BadMap = #{<<"root">> => #{BadKey => #{<<"foo">> => #{}}}},
+                ?assertMatch(
+                    #{<<"root">> := #{BadKey := _}},
+                    hocon_tconf:check_plain(
+                        Sc,
+                        BadMap,
+                        #{atom_key => false}
+                    )
+                )
             end)}
     ].
 


### PR DESCRIPTION
The Erlang VM only supports [atoms up to 255 bytes](https://www.erlang.org/doc/efficiency_guide/advanced#system-limits), so we should validate the length before attempting the conversion.