### PR TITLE
fix(hocon_tconf): do not obfuscate 'undefined' as "******"

### DIFF
--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -995,6 +995,10 @@ ensure_obfuscate_sensitive(Opts, Schema, Val) ->
             Val
     end.
 
+%% Should not replace 'undefined' with "******" because we want to
+%% be able to tell if value existed or not.
+obfuscate(_Schema, undefined) ->
+    undefined;
 obfuscate(Schema, Value) ->
     case field_schema(Schema, sensitive) of
         true -> <<"******">>;

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -35,6 +35,7 @@ fields(bar) ->
     [
         {union_with_default, fun union_with_default/1},
         {field1, fun field1/1},
+        {optional_secret, fun optional_secret/1},
         {host, fun host/1}
     ];
 fields(parent) ->
@@ -68,6 +69,12 @@ field1(type) -> string();
 field1(desc) -> "field1 desc";
 field1(sensitive) -> true;
 field1(_) -> undefined.
+
+optional_secret(type) -> string();
+optional_secret(desc) -> "optional secret";
+optional_secret(sensitive) -> true;
+optional_secret(required) -> false;
+optional_secret(_) -> undefined.
 
 host(type) -> string();
 host(required) -> false;


### PR DESCRIPTION
Otherwise it's impossible to tell if the original value existed or not when an obfuscated struct is sent back for comparism.