### PR TITLE
0213 multiline string indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ HOCON spec for reference: https://lightbend.github.io/config/
     * `key={a: 1}\n{b: 2}`
     * `key={a=1, b=2}`
 - `url()/file()/classpath()` includes are not supported
+- Quotes next to triple-quotes needs to be escaped, otherwise they are discarded.
+  Meaning `"""a""""` is parsed as `a` but not `a"`, to crrectly express `a"`, it must be one of below:
+    * Escape the last `"`: `"""a\""""`;
+    * Or add `~` around the string value: `"""~a"~"""` (see below).
+- Multiline strings allow indentation (spaces, not tabs).
+  If `~\n` (or `~\r\n`) are the only characters following the opening triple-quote, then it's a multiline string with indentation:
+    * The first line `~\n` is ignored;
+    * The indentation spaces of the following lines are trimed;
+    * Indentation is allowed but not required for empty lines;
+    * Indentation level is determined by the least number of leading spaces among the non-empty lines;
+    * Backslashes are treated as escape characters, i.e. should be escaped with another backslash;
+    * There is no need to escape quotes in multiline strings, but it's allowed;
+    * The closing triple-quote can be either `"""` or `~"""` (`~` allows the string to end with `"` without escaping).
 
 ## Schema
 

--- a/etc/unescape.conf
+++ b/etc/unescape.conf
@@ -5,6 +5,6 @@ sql_laitin1_with_escape_1 = "SELECT * FROM \"t/1\""
 sql_laitin1_with_escape_2 = "SELECT * FROM \\\"t/1\\\""
 sql_unicode_with_escape_1 = "SELECT * FROM \"t/1\" WHERE clientid = \"-测试专用-\""
 sql_unicode_with_escape_2 = "SELECT * FROM \\\"t/1\\\" WHERE clientid = \"-测试专用-\""
-sql_unicode_with_escape_3 = "SELECT * FROM \\\"t/1\\\" WHERE clientid = \"-测试\\\n\r\t专用-\""
+sql_unicode_with_escape_3 = "SELECT * FROM \\\"t/1\\\" WHERE clientid = \"-测试\\\r\n\t专用-\""
 z = 1
 z1 = "1"

--- a/src/hocon_pp.erl
+++ b/src/hocon_pp.erl
@@ -185,19 +185,19 @@ indent_multiline_str(Chars) ->
     Lines = hocon_scanner:split_lines(Chars),
     indent_str_value_lines(Lines).
 
-%% mark each line for indentation with 'indent_multiline_str'
+%% mark each line for indentation with 'indent'
 %% except for empty lines in the middle of the string
 indent_str_value_lines([[]]) ->
     %% last line being empty
     [?NL];
 indent_str_value_lines([LastLine]) ->
     %% last line is not empty
-    [{indent_multiline_str, bin(LastLine)}];
+    [{indent, bin(LastLine)}];
 indent_str_value_lines([[] | Lines]) ->
     %% do not indent empty line
     [<<"\n">> | indent_str_value_lines(Lines)];
 indent_str_value_lines([Line | Lines]) ->
-    [{indent_multiline_str, bin(Line)} | indent_str_value_lines(Lines)].
+    [{indent, bin(Line)} | indent_str_value_lines(Lines)].
 
 gen_list(L, Opts) ->
     case is_oneliner(L) of
@@ -205,20 +205,20 @@ gen_list(L, Opts) ->
             %% one line
             ["[", infix([gen(I, Opts) || I <- L], ", "), "]"];
         false ->
-            do_gen_list(L, Opts)
+            gen_multiline_list(L, Opts)
     end.
 
-do_gen_list([_ | _] = L, Opts) ->
+gen_multiline_list([_ | _] = L, Opts) ->
     [
-        ["[", ?NL],
-        do_gen_list_loop(L, Opts#{no_obj_nl => true}),
+        ["["],
+        gen_multiline_list_loop(L, Opts#{no_obj_nl => true}),
         ["]", ?NL]
     ].
 
-do_gen_list_loop([I], Opts) ->
+gen_multiline_list_loop([I], Opts) ->
     [{indent, gen(I, Opts)}];
-do_gen_list_loop([H | T], Opts) ->
-    [{indent, [gen(H, Opts), ","]} | do_gen_list_loop(T, Opts)].
+gen_multiline_list_loop([H | T], Opts) ->
+    [{indent, [gen(H, Opts), ","]} | gen_multiline_list_loop(T, Opts)].
 
 is_oneliner(L) when is_list(L) ->
     lists:all(fun(X) -> is_number(X) orelse is_binary(X) orelse is_atom(X) end, L);
@@ -228,7 +228,7 @@ is_oneliner(M) when is_map(M) ->
 gen_map(M, Opts) ->
     case is_oneliner(M) of
         true -> ["{", infix(gen_map_fields(M, Opts, ""), ", "), "}"];
-        false -> [["{", ?NL], {indent, gen_map_fields(M, Opts, ?NL)}, "}"]
+        false -> ["{", {indent, gen_map_fields(M, Opts, ?NL)}, [?NL, "}"]]
     end.
 
 gen_map_fields(M, Opts, NL) ->
@@ -297,11 +297,9 @@ fmt(I) when is_integer(I) -> I;
 fmt(B) when is_binary(B) -> B;
 fmt(L) when is_list(L) ->
     bin(lists:map(fun fmt/1, L));
-fmt({indent_multiline_str, Line}) ->
-    bin([?NL, ?INDENT, Line]);
 fmt({indent, Block}) ->
     FormattedBlock = fmt(Block),
-    bin([[?INDENT, Line, ?NL] || Line <- split(FormattedBlock)]).
+    bin([[?NL, ?INDENT, Line] || Line <- split(FormattedBlock)]).
 
 split(Bin) ->
     [Line || Line <- binary:split(Bin, ?NL, [global]), Line =/= <<>>].

--- a/src/hocon_pp.erl
+++ b/src/hocon_pp.erl
@@ -183,16 +183,21 @@ maybe_indent(Chars) ->
 
 indent_multiline_str(Chars) ->
     Lines = hocon_scanner:split_lines(Chars),
-    lists:map(
-        fun
-            ([]) ->
-                %% do not indent empty line
-                <<"\n">>;
-            (Line) ->
-                {indent_multiline_str, bin(Line)}
-        end,
-        Lines
-    ).
+    indent_str_value_lines(Lines).
+
+%% mark each line for indentation with 'indent_multiline_str'
+%% except for empty lines in the middle of the string
+indent_str_value_lines([[]]) ->
+    %% last line being empty
+    [?NL];
+indent_str_value_lines([LastLine]) ->
+    %% last line is not empty
+    [{indent_multiline_str, bin(LastLine)}];
+indent_str_value_lines([[] | Lines]) ->
+    %% do not indent empty line
+    [<<"\n">> | indent_str_value_lines(Lines)];
+indent_str_value_lines([Line | Lines]) ->
+    [{indent_multiline_str, bin(Line)} | indent_str_value_lines(Lines)].
 
 gen_list(L, Opts) ->
     case is_oneliner(L) of

--- a/test/hocon_pp_tests.erl
+++ b/test/hocon_pp_tests.erl
@@ -115,7 +115,7 @@ pp_quote_test() ->
     ok.
 
 multi_line_str_indent_test() ->
-    Struct = #{<<"a">> => #{<<"b">> => #{<<"c">> => "line1\n\nline2\n\nline3"}}},
+    Struct = #{<<"a">> => #{<<"b">> => #{<<"c">> => "line1\n\nline2\n\nline3\n"}}},
     Expected = <<
         "a {\n"
         "  b {\n"
@@ -124,7 +124,8 @@ multi_line_str_indent_test() ->
         "\n"
         "      line2\n"
         "\n"
-        "      line3~\"\"\"\n"
+        "      line3\n"
+        "    ~\"\"\"\n"
         "  }\n"
         "}\n"
     >>,

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -268,8 +268,27 @@ escape_test_() ->
         )
     ].
 
-multiline_string_test_() ->
-    [].
+triple_quote_string_test_() ->
+    Parse = fun(Str) -> maps:get(<<"a">>, binary(<<"a = \"\"\"", Str/binary, "\"\"\"">>)) end,
+    [
+        ?_assertEqual(<<"1">>, Parse(<<"1">>)),
+        ?_assertEqual(<<"1">>, Parse(<<"~\n1~">>)),
+        ?_assertEqual(<<"1\n">>, Parse(<<"~\n1\n~">>)),
+        ?_assertEqual(<<"1\r\n">>, Parse(<<"~\r\n1\r\n">>)),
+        ?_assertEqual(<<"1\n\n2">>, Parse(<<"~\n1\n\n2">>)),
+        ?_assertEqual(<<"1\n\n2">>, Parse(<<"~\n    1\n\n    2">>)),
+        ?_assertEqual(<<"1\n\n2">>, Parse(<<"~\n    1\n    \n    2">>)),
+        ?_assertEqual(<<" 1\n\n2">>, Parse(<<"~\n     1\n    \n    2">>)),
+        ?_assertEqual(<<" 1\n\n2\n">>, Parse(<<"~\n     1\n    \n    2\n">>)),
+        ?_assertEqual(<<"1\"\"\n2">>, Parse(<<"~\n     1\"\"\n     2">>)),
+        %% escape quotes if it's next to """
+        ?_assertEqual(<<"1\"">>, Parse(<<"1\\\"">>)),
+        %% escape quotes if it's next to """
+        ?_assertEqual(<<"\"1">>, Parse(<<"\\\"1">>)),
+        %% no need to escape quotes unless it's next to """
+        ?_assertEqual(<<"1\"2">>, Parse(<<"1\"2">>)),
+        ?_assertEqual(<<"">>, Parse(<<"~\n">>))
+    ].
 
 obj_inside_array_test_() ->
     [

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -280,14 +280,20 @@ triple_quote_string_test_() ->
         ?_assertEqual(<<"1\n\n2">>, Parse(<<"~\n    1\n    \n    2">>)),
         ?_assertEqual(<<" 1\n\n2">>, Parse(<<"~\n     1\n    \n    2">>)),
         ?_assertEqual(<<" 1\n\n2\n">>, Parse(<<"~\n     1\n    \n    2\n">>)),
+        ?_assertEqual(<<" 1\n\n2\n">>, Parse(<<"~\n     1\n    \n    2\n    ">>)),
+        ?_assertEqual(<<" 1\n\n2\n">>, Parse(<<"~\n     1\n    \n    2\n    ~">>)),
+        ?_assertEqual(<<" 1\n\n2\n ">>, Parse(<<"~\n     1\n    \n    2\n     ~">>)),
         ?_assertEqual(<<"1\"\"\n2">>, Parse(<<"~\n     1\"\"\n     2">>)),
-        %% escape quotes if it's next to """
+        %% must escape quotes if it's next to """
         ?_assertEqual(<<"1\"">>, Parse(<<"1\\\"">>)),
-        %% escape quotes if it's next to """
+        %% must escape quotes if it's next to """
         ?_assertEqual(<<"\"1">>, Parse(<<"\\\"1">>)),
         %% no need to escape quotes unless it's next to """
         ?_assertEqual(<<"1\"2">>, Parse(<<"1\"2">>)),
-        ?_assertEqual(<<"">>, Parse(<<"~\n">>))
+        %% empty string with closing quote in the next line
+        ?_assertEqual(<<"">>, Parse(<<"~\n">>)),
+        %% empty string with indented closing quote in the next line
+        ?_assertEqual(<<"">>, Parse(<<"~\n    ~">>))
     ].
 
 obj_inside_array_test_() ->


### PR DESCRIPTION
now we can do this:
```
a {
  b {
    c = """~
      line1

      line2

      line3
    ~"""
  }
}
```
More practical examples:
```
rule_engine {
  ignore_sys_message = true
  jq_function_default_timeout = 10s
  rules {
    a_WH_D {
      actions = ["http:a_WH_D"]
      description = ""
      enable = true
      metadata {created_at = 1707562385536}
      name = ""
      sql = """~
        SELECT
          *
        FROM
          "#",
          "$events/message_delivered",
          "$events/message_acked",
          "$events/message_dropped",
          "$events/client_connected",
          "$events/client_disconnected",
          "$events/client_connack",
          "$events/client_check_authz_complete",
          "$events/session_subscribed",
          "$events/session_unsubscribed",
          "$events/delivery_dropped"~"""
    }
    rule_rc0w {
      actions = [
        {
          args {
            mqtt_properties {}
            payload = "${.}"
            qos = 0
            retain = false
            topic = "republish-event/${clientid}"
            user_properties = ""
          }
          function = republish
        },
        {function = console}
      ]
      enable = true
      metadata {created_at = 1707389712653}
      name = ""
      sql = """~
        SELECT
          *
        FROM
          "$events/client_connected",
          "$events/client_disconnected"
      ~"""
    }
    rule_xlu4 {
      actions = [
        {function = console}
      ]
      description = ""
      enable = true
      metadata {created_at = 1706611936022}
      name = ""
      sql = """~
        SELECT
          *
        FROM
          "t/#"
      ~"""
    }
  }
}
```