### PR TITLE
refactor: improve indentation rendering

### DIFF
--- a/include/hocon_private.hrl
+++ b/include/hocon_private.hrl
@@ -21,6 +21,4 @@
 -define(HOCON_V, '$hcVal').
 -define(HOCON_T, '$hcTyp').
 
-%% random magic bytes to work as newline instead of "\n"
--define(NL, <<"magic-chicken", 255, 156, 173, 82, 187, 168, 136>>).
 -endif.

--- a/test/hocon_pp_tests.erl
+++ b/test/hocon_pp_tests.erl
@@ -115,7 +115,16 @@ pp_quote_test() ->
     ok.
 
 multi_line_str_indent_test() ->
-    Struct = #{<<"a">> => #{<<"b">> => #{<<"c">> => "line1\n\nline2\n\nline3\n"}}},
+    Struct = #{
+        <<"a">> => #{
+            <<"b">> => #{
+                <<"c">> => <<"line1\n\nline2\n\nline3\n">>,
+                <<"d">> => 1
+            },
+            <<"e">> => 2,
+            <<"emptystring">> => <<>>
+        }
+    },
     Expected = <<
         "a {\n"
         "  b {\n"
@@ -126,8 +135,39 @@ multi_line_str_indent_test() ->
         "\n"
         "      line3\n"
         "    ~\"\"\"\n"
+        "    d = 1\n"
         "  }\n"
+        "  e = 2\n"
+        "  emptystring = \"\"\n"
         "}\n"
+    >>,
+    ?assertEqual(Expected, iolist_to_binary(hocon_pp:do(Struct, #{}))),
+    ok.
+
+array_elements_indent_test() ->
+    Struct = #{
+        <<"a">> => [
+            #{
+                <<"b">> => #{
+                    <<"c">> => <<"not a simple string because of '#'">>,
+                    <<"d">> => 1
+                }
+            },
+            #{<<"e">> => 2}
+        ],
+        <<"b">> => <<"x">>
+    },
+    Expected = <<
+        "a = [\n"
+        "  {\n"
+        "    b {\n"
+        "      c = \"not a simple string because of '#'\"\n"
+        "      d = 1\n"
+        "    }\n"
+        "  },\n"
+        "  {e = 2}\n"
+        "]\n"
+        "b = x\n"
     >>,
     ?assertEqual(Expected, iolist_to_binary(hocon_pp:do(Struct, #{}))),
     ok.


### PR DESCRIPTION
Prior to this refactoring, the pretty-print indentation implementation relies on a lot of binary split and reassembling operations.
This change made the indentation insertion when recursively generating the lines.