### PR TITLE
fix(hocon_scanner): ignore identation of the closing triple-quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,14 @@ HOCON spec for reference: https://lightbend.github.io/config/
     * Or add `~` around the string value: `"""~a"~"""` (see below).
 - Multiline strings allow indentation (spaces, not tabs).
   If `~\n` (or `~\r\n`) are the only characters following the opening triple-quote, then it's a multiline string with indentation:
-    * The first line `~\n` is ignored;
-    * The indentation spaces of the following lines are trimed;
+    * The first line `~\n` is discarded;
+    * The closing triple-quote can be either `"""` or `~"""` (`~` allows the string to end with `"` without escaping).
     * Indentation is allowed but not required for empty lines;
     * Indentation level is determined by the least number of leading spaces among the non-empty lines;
+    * If the closing triple-quote takes the whole line, it's allowed to be indented less than other lines,
+      but if it's indented more than other lines, the spaces are treated as part of the string.
     * Backslashes are treated as escape characters, i.e. should be escaped with another backslash;
-    * There is no need to escape quotes in multiline strings, but it's allowed;
-    * The closing triple-quote can be either `"""` or `~"""` (`~` allows the string to end with `"` without escaping).
+    * There is no need to escape quotes in multiline strings, but it's allowed.
 
 ## Schema
 

--- a/test/hocon_pp_tests.erl
+++ b/test/hocon_pp_tests.erl
@@ -333,3 +333,28 @@ no_triple_quote_string_when_oneliner_test_() ->
         ),
         ?_assertEqual([<<"root {a = \"a\\nb\"}">>], hocon_pp:do(Value, #{newline => <<>>}))
     ].
+
+crlf_multiline_test_() ->
+    Value = #{<<"root">> => #{<<"x">> => <<"\r\n\r\na\r\nb\n">>}},
+    CRLF = <<"\r\n">>,
+    IndentCRLF = <<"    \r\n">>,
+    Hocon = fun(NewLine) ->
+        [
+            <<"root {\r\n">>,
+            <<"  x = \"\"\"~\r\n">>,
+            NewLine,
+            NewLine,
+            <<"    a\r\n">>,
+            %% the last newline is just \n, should not be replaced
+            <<"    b\n">>,
+            <<"  ~\"\"\"\r\n">>,
+            <<"}\r\n">>
+        ]
+    end,
+    Expected = Hocon(CRLF),
+    Variant = Hocon(IndentCRLF),
+    [
+        ?_assertEqual(Expected, hocon_pp:do(Value, #{newline => "\r\n"})),
+        ?_assertEqual({ok, Value}, hocon:binary(Expected)),
+        ?_assertEqual({ok, Value}, hocon:binary(Variant))
+    ].

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -293,7 +293,11 @@ triple_quote_string_test_() ->
         %% empty string with closing quote in the next line
         ?_assertEqual(<<"">>, Parse(<<"~\n">>)),
         %% empty string with indented closing quote in the next line
-        ?_assertEqual(<<"">>, Parse(<<"~\n    ~">>))
+        ?_assertEqual(<<"">>, Parse(<<"~\n    ~">>)),
+        %% last line is space only, must indent more than other non-space-only lines
+        ?_assertEqual(<<"a\n  ">>, Parse(<<"~\n  a\n    ~">>)),
+        %% last line is space only, ignored if it indents less than other non-space-only lines
+        ?_assertEqual(<<"a\n">>, Parse(<<"~\n    a\n  ~">>))
     ].
 
 obj_inside_array_test_() ->


### PR DESCRIPTION
In a indented multiline string, the closing `"""` or `~"""` can be indented less than the other lines.
When parsing the value, the all-space last line should not be used to identify the minimum indentation.

Also implemented more complete support for CRLF newlines in multiline string,
previously, a line with only `\r` is not considered empty hence indented.