### PR TITLE
refactor: make namespace/0 a non-optional export

### DIFF
--- a/sample-schemas/demo_schema.erl
+++ b/sample-schemas/demo_schema.erl
@@ -14,10 +14,11 @@
 
 -reflect_type([duration/0, percent/0]).
 
--export([roots/0, fields/1, translations/0, translation/1]).
+-export([roots/0, fields/1, translations/0, translation/1, namespace/0]).
 
 -define(FIELD(NAME, TYPE), hoconsc:mk(TYPE, #{mapping => NAME})).
 
+namespace() -> "demo".
 roots() -> [foo, {"a_b", hoconsc:mk(hoconsc:ref("a_b"), #{importance => hidden})}, "b", person, "vm"].
 translations() -> ["app_foo"].
 

--- a/sample-schemas/emqx_auth_http_schema.erl
+++ b/sample-schemas/emqx_auth_http_schema.erl
@@ -4,8 +4,9 @@
 
 -behaviour(hocon_schema).
 
--export([roots/0, fields/1, translations/0, translation/1]).
+-export([roots/0, fields/1, translations/0, translation/1, namespace/0]).
 
+namespace() -> "auth_http".
 roots() -> ["auth"].
 
 fields("auth") ->

--- a/sample-schemas/emqx_auth_jwt_schema.erl
+++ b/sample-schemas/emqx_auth_jwt_schema.erl
@@ -4,8 +4,9 @@
 
 -behaviour(hocon_schema).
 
--export([roots/0, fields/1, translations/0, translation/1]).
+-export([roots/0, fields/1, translations/0, translation/1, namespace/0]).
 
+namespace() -> "auth_jwt".
 roots() -> ["auth"].
 
 fields("auth") ->

--- a/sample-schemas/emqx_auth_ldap_schema.erl
+++ b/sample-schemas/emqx_auth_ldap_schema.erl
@@ -4,8 +4,9 @@
 
 -behaviour(hocon_schema).
 
--export([roots/0, fields/1, translations/0, translation/1]).
+-export([roots/0, fields/1, translations/0, translation/1, namespace/0]).
 
+namespace() -> "auth_ldap".
 roots() -> ["auth"].
 
 fields("auth") ->

--- a/sample-schemas/emqx_auth_mnesia_schema.erl
+++ b/sample-schemas/emqx_auth_mnesia_schema.erl
@@ -4,8 +4,9 @@
 
 -behaviour(hocon_schema).
 
--export([roots/0, fields/1, translations/0, translation/1]).
+-export([roots/0, fields/1, translations/0, translation/1, namespace/0]).
 
+namespace() -> "auth_mnesia".
 roots() -> ["auth"].
 
 fields("auth") ->

--- a/sample-schemas/emqx_auth_mongo_schema.erl
+++ b/sample-schemas/emqx_auth_mongo_schema.erl
@@ -11,8 +11,9 @@
 
 -reflect_type([type/0, w_mode/0, r_mode/0]).
 
--export([roots/0, fields/1, translations/0, translation/1]).
+-export([roots/0, fields/1, translations/0, translation/1, namespace/0]).
 
+namespace() -> "auth_mongo".
 roots() -> ["auth"].
 
 fields("auth") ->

--- a/sample-schemas/emqx_auth_mysql_schema.erl
+++ b/sample-schemas/emqx_auth_mysql_schema.erl
@@ -4,10 +4,11 @@
 
 -behaviour(hocon_schema).
 
--export([roots/0, fields/1, translations/0, translation/1]).
+-export([roots/0, fields/1, translations/0, translation/1, namespace/0]).
 
 roots() -> ["auth"].
 
+namespace() -> "auth_mysql".
 fields("auth") ->
     [ {"mysql", emqx_schema:ref("mysql")}];
 

--- a/sample-schemas/emqx_auth_pgsql_schema.erl
+++ b/sample-schemas/emqx_auth_pgsql_schema.erl
@@ -4,8 +4,9 @@
 
 -behaviour(hocon_schema).
 
--export([roots/0, fields/1, translations/0, translation/1]).
+-export([roots/0, fields/1, translations/0, translation/1, namespace/0]).
 
+namespace() -> "auth_pgsql".
 roots() -> ["auth"].
 
 fields("auth") ->

--- a/sample-schemas/emqx_auth_redis_schema.erl
+++ b/sample-schemas/emqx_auth_redis_schema.erl
@@ -4,8 +4,9 @@
 
 -behaviour(hocon_schema).
 
--export([roots/0, fields/1, translations/0, translation/1]).
+-export([roots/0, fields/1, translations/0, translation/1, namespace/0]).
 
+namespace() -> "auth_redis".
 roots() -> ["auth"].
 
 fields("auth") ->

--- a/sample-schemas/emqx_management_schema.erl
+++ b/sample-schemas/emqx_management_schema.erl
@@ -9,8 +9,9 @@
 
 -reflect_type([endpoint/0, verify/0]).
 
--export([roots/0, fields/1, translations/0, translation/1]).
+-export([roots/0, fields/1, translations/0, translation/1, namespace/0]).
 
+namespace() -> "management".
 roots() -> ["management"].
 
 fields("management") ->

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -74,7 +74,6 @@
 -callback tags() -> [tag()].
 
 -optional_callbacks([
-    roots/0,
     translations/0,
     translation/1,
     validations/0,
@@ -226,10 +225,7 @@ override(Base, OnTop) ->
 namespace(Schema) ->
     case is_atom(Schema) of
         true ->
-            case erlang:function_exported(Schema, namespace, 0) of
-                true -> Schema:namespace();
-                false -> undefined
-            end;
+            Schema:namespace();
         false ->
             maps:get(namespace, Schema, undefined)
     end.

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -20,7 +20,7 @@
 -include("hocon_private.hrl").
 -include("hoconsc.hrl").
 
--export([roots/0, fields/1, validations/0, desc/1]).
+-export([roots/0, fields/1, validations/0, desc/1, namespace/0]).
 
 -define(GEN_VALIDATION_ERR(Reason, Expr),
     ?_assertThrow({_, [Reason]}, Expr)
@@ -29,6 +29,7 @@
     ?assertThrow({_, [Reason]}, Expr)
 ).
 
+namespace() -> bar.
 roots() -> [bar].
 
 fields(bar) ->


### PR DESCRIPTION
The `erlang:function_exported(Schema, namespace, 0)` prevents the module from being loaded in interactive mode.