### PR TITLE
fix(typespec): fix `hocon_schema:override` typespec

### DIFF
--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -132,7 +132,7 @@
         %% deprecated field can not be removed due to compatibility reasons.
         %% The value will be dropped,
         %% Deprecated fields are treated as required => {false, recursively}
-        deprecated => {since, binary()} | false,
+        deprecated => {since, binary() | string()} | false,
         %% Other names to reference this field.
         %% this can be useful when we need to rename some filed names
         %% while keeping backward compatibility.


### PR DESCRIPTION
We commonly use `deprecated => {since, "x.y.z"}`, but that is not what the typespec expects.

```
Line 72 Column 50: The call hocon_schema:override(Sc::atom() | fun((_) -> any()) | maybe_improper_list() | tuple() | map(), Override::#{'default':=[], 'deprecated':={'since',[46 | 48 | 53 | 54 | 101,...]}, 'importance':='hidden', 'required':='false', 'type':=_, 'validator':=fun((_) -> 'ok')}) breaks the contract (field_schema(), field_schema_map()) -> field_schema_fun()
```