### PR TITLE
refactor: print more string values quoted

### DIFF
--- a/test/hocon_pp_tests.erl
+++ b/test/hocon_pp_tests.erl
@@ -73,9 +73,9 @@ pp_quote_test() ->
         ?assertEqual(Map, Map2)
     end,
     %% normal without quote
-    Fun(#{<<"d_dfdk2f">> => <<"19%">>}, <<"d_dfdk2f = 19%\n">>),
+    Fun(#{<<"d_dfdk2f">> => <<"19%">>}, <<"d_dfdk2f = \"19%\"\n">>),
     %% key begin with integer should be quote
-    Fun(#{<<"1f">> => <<"1d">>}, <<"\"1f\" = 1d\n">>),
+    Fun(#{<<"1f">> => <<"1d">>}, <<"\"1f\" = \"1d\"\n">>),
     %% key begin with _ should be quote
     Fun(#{<<"_f">> => 12}, <<"\"_f\" = 12\n">>),
     %% value contain special char should be quote


### PR DESCRIPTION
Now below strings are quoted (although they are unquoted strings):
1. Strings starts with digits, e.g. "12kb"
2. Strings have `.` or `-`

This is to help other libs (such as golang) which have trouble parsing such values.