### PR TITLE
chore: add more info to errors

### DIFF
--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -282,7 +282,16 @@ fields_and_meta(Mod, Name) when is_atom(Mod) ->
                 ensure_struct_meta(Fields)
         catch
             K:E:S ->
-                erlang:raise(K, #{error => "failed to resolve schema", cause => E, schema_module => Mod, struct_name => Name}, S)
+                erlang:raise(
+                    K,
+                    #{
+                        error => "failed to resolve schema",
+                        cause => E,
+                        schema_module => Mod,
+                        struct_name => Name
+                    },
+                    S
+                )
         end,
     Meta#{tags => tags(Mod)};
 fields_and_meta(#{fields := Fields}, Name) when is_function(Fields) ->
@@ -300,7 +309,16 @@ maybe_add_desc(Mod, Name, Meta) ->
                     Meta#{desc => Desc}
             catch
                 K:E:S ->
-                    erlang:raise(K, #{error => "failed to resolve struct description", cause => E, schema_module => Mod, struct_name => Name}, S)
+                    erlang:raise(
+                        K,
+                        #{
+                            error => "failed to resolve struct description",
+                            cause => E,
+                            schema_module => Mod,
+                            struct_name => Name
+                        },
+                        S
+                    )
             end;
         false ->
             Meta

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -282,7 +282,7 @@ fields_and_meta(Mod, Name) when is_atom(Mod) ->
                 ensure_struct_meta(Fields)
         catch
             K:E:S ->
-                throw(#{kind => K, reason => E, stacktrace => S})
+                erlang:raise(K, #{error => "failed to resolve schema", cause => E, schema_module => Mod, struct_name => Name}, S)
         end,
     Meta#{tags => tags(Mod)};
 fields_and_meta(#{fields := Fields}, Name) when is_function(Fields) ->
@@ -300,7 +300,7 @@ maybe_add_desc(Mod, Name, Meta) ->
                     Meta#{desc => Desc}
             catch
                 K:E:S ->
-                    throw(#{kind => K, reason => E, stacktrace => S})
+                    erlang:raise(K, #{error => "failed to resolve struct description", cause => E, schema_module => Mod, struct_name => Name}, S)
             end;
         false ->
             Meta

--- a/src/hocon_schema.erl
+++ b/src/hocon_schema.erl
@@ -275,11 +275,14 @@ fields(Sc, Name) ->
 -spec fields_and_meta(schema(), name()) -> fields().
 fields_and_meta(Mod, Name) when is_atom(Mod) ->
     Meta =
-        case Mod:fields(Name) of
+        try Mod:fields(Name) of
             Fields when is_list(Fields) ->
                 maybe_add_desc(Mod, Name, #{fields => Fields});
             Fields ->
                 ensure_struct_meta(Fields)
+        catch
+            K:E:S ->
+                throw(#{kind => K, reason => E, stacktrace => S})
         end,
     Meta#{tags => tags(Mod)};
 fields_and_meta(#{fields := Fields}, Name) when is_function(Fields) ->
@@ -290,11 +293,14 @@ fields_and_meta(#{fields := Fields}, Name) when is_map(Fields) ->
 maybe_add_desc(Mod, Name, Meta) ->
     case erlang:function_exported(Mod, desc, 1) of
         true ->
-            case Mod:desc(Name) of
+            try Mod:desc(Name) of
                 undefined ->
                     Meta;
                 Desc ->
                     Meta#{desc => Desc}
+            catch
+                K:E:S ->
+                    throw(#{kind => K, reason => E, stacktrace => S})
             end;
         false ->
             Meta


### PR DESCRIPTION
Minor change to replace `function_clause` with a bit more info to track down the error.

Before the change:

```
[error] input-config:
  '$hcVal' =>
      [#{'$hcTyp' => object,
         '$hcVal' =>
             #{<<"key">> =>
                   #{'$hcTyp' => string,'$hcVal' => <<"ts">>,
                     '$hcMeta' =>
                         #{line => 45,
                           filename =>
                               "/home/thales/dev/emqx/emqx/_build/emqx-enterprise/rel/emqx/data/configs/cluster.hocon"}},
               <<"value">> =>
                   #{'$hcTyp' => string,
                     '$hcVal' => <<"concat([topic, '/', a.b])">>,
                     '$hcMeta' =>
                         #{line => 46,
                           filename =>
                               "/home/thales/dev/emqx/emqx/_build/emqx-enterprise/rel/emqx/data/configs/cluster.hocon"}}},
         '$hcMeta' =>
             #{line => 46,
               filename =>
                   "/home/thales/dev/emqx/emqx/_build/emqx-enterprise/rel/emqx/data/configs/cluster.hocon"}}],
  '$hcMeta' =>
      #{line => 43,
        filename =>
            "/home/thales/dev/emqx/emqx/_build/emqx-enterprise/rel/emqx/data/configs/cluster.hocon"}}
  path => "message_transformation.transformations.1",
  exception => function_clause,field => <<"transform">>} <----------------------------------------

escript: exception error: #{reason => failed_to_check_field,
                   path => "message_transformation.transformations.1",
                   exception => function_clause,field => <<"transform">>}
  in function  emqx_message_transformation_schema:fields/1
     called as emqx_message_transformation_schema:fields(transform_kv222)
  in call from hocon_schema:fields_and_meta/2 (hocon_schema.erl, line 278)
  in call from hocon_schema:fields/2 (hocon_schema.erl, line 271)
  in call from hocon_tconf:map_field/4 (hocon_tconf.erl, line 584)
  in call from hocon_tconf:map_one_field_non_hidden/4 (hocon_tconf.erl, line 492)
  in call from hocon_tconf:do_map_array/5 (hocon_tconf.erl, line 801)
  in call from hocon_tconf:'-map_field/4-fun-4-'/4 (hocon_tconf.erl, line 622)
  in call from hocon_tconf:map_one_field_non_hidden/4 (hocon_tconf.erl, line 492)

```

After the change:

```
...
  path => "message_transformation.transformations.1",
  exception =>
      #{reason => function_clause, <-----------------------------------------------------
        stacktrace =>
            [{emqx_message_transformation_schema,fields,
                 [operation_wrong_ref],
                 [{file,"emqx_message_transformation_schema.erl"},{line,39}]},
             {hocon_schema,fields_and_meta,2,
                 [{file,"hocon_schema.erl"},{line,278}]},
             {hocon_schema,fields,2,[{file,"hocon_schema.erl"},{line,271}]},
             {hocon_tconf,map_field,4,[{file,"hocon_tconf.erl"},{line,581}]},
             {hocon_tconf,map_one_field_non_hidden,4,
                 [{file,"hocon_tconf.erl"},{line,492}]},
             {hocon_tconf,do_map_array,5,
                 [{file,"hocon_tconf.erl"},{line,798}]},
             {hocon_tconf,'-map_field/4-fun-4-',4,
                 [{file,"hocon_tconf.erl"},{line,619}]},
             {hocon_tconf,map_one_field_non_hidden,4,
                 [{file,"hocon_tconf.erl"},{line,492}]}],
        kind => error},
  field => <<"operations">>}

escript: exception throw: #{reason => failed_to_check_field,
                   path => "message_transformation.transformations.1",
                   exception =>
                       #{reason => function_clause,
                         stacktrace =>
                             [{emqx_message_transformation_schema,fields,
                                  [operation_wrong_ref],
                                  [{file,
                                       "emqx_message_transformation_schema.erl"},
                                   {line,39}]},
                              {hocon_schema,fields_and_meta,2,
                                  [{file,"hocon_schema.erl"},{line,278}]},
                              {hocon_schema,fields,2,
                                  [{file,"hocon_schema.erl"},{line,271}]},
                              {hocon_tconf,map_field,4,
                                  [{file,"hocon_tconf.erl"},{line,581}]},
                              {hocon_tconf,map_one_field_non_hidden,4,
                                  [{file,"hocon_tconf.erl"},{line,492}]},
                              {hocon_tconf,do_map_array,5,
                                  [{file,"hocon_tconf.erl"},{line,798}]},
                              {hocon_tconf,'-map_field/4-fun-4-',4,
                                  [{file,"hocon_tconf.erl"},{line,619}]},
                              {hocon_tconf,map_one_field_non_hidden,4,
                                  [{file,"hocon_tconf.erl"},{line,492}]}],
                         kind => error},
                   field => <<"operations">>}
```