### PR TITLE
fix: no alias for map fields

### DIFF
--- a/src/hocon_tconf.erl
+++ b/src/hocon_tconf.erl
@@ -561,9 +561,16 @@ map_field(?MAP(NameType, Type), FieldSchema, Value, Opts) ->
             case check_map_key_name(NameType, FieldNames) of
                 ok ->
                     %% All objects in this map should share the same schema.
+                    %% And each fake 'field' should not have any alias
+                    %% because the alias belongs to the parent field
                     NewSc = hocon_schema:override(
                         FieldSchema,
-                        #{type => Type, mapping => undefined, converter => undefined}
+                        #{
+                            type => Type,
+                            mapping => undefined,
+                            converter => undefined,
+                            aliases => []
+                        }
                     ),
                     NewFields = [{FieldName, NewSc} || FieldName <- FieldNames],
                     %% start over

--- a/test/hocon_tconf_tests.erl
+++ b/test/hocon_tconf_tests.erl
@@ -2571,3 +2571,18 @@ random_key() ->
     Bytes = crypto:strong_rand_bytes(10),
     Key0 = base64:encode(Bytes),
     iolist_to_binary(re:replace(Key0, <<"[^-a-zA-Z0-9_]">>, <<>>, [global])).
+
+map_type_with_alias_test() ->
+    Sc = #{
+        roots => [
+            {"root", hoconsc:mk(hoconsc:map(name, hoconsc:ref(foo)), #{aliases => [foo]})}
+        ],
+        fields =>
+            #{foo => [{bar, hoconsc:mk(integer(), #{})}]}
+    },
+    MapValue = #{<<"foo">> => #{<<"bar">> => 0}},
+    NormalRecord = #{<<"root">> => MapValue},
+    AliasedRecord = #{<<"foo">> => MapValue},
+    ?assertEqual(NormalRecord, hocon_tconf:check_plain(Sc, NormalRecord)),
+    ?assertEqual(NormalRecord, hocon_tconf:check_plain(Sc, AliasedRecord)),
+    ok.


### PR DESCRIPTION
This fixes the crash like below:

2024-09-06T11:55:41.141104+02:00 [warning] reason: {case_clause,{error,{config_update_crashed,#{reason => failed_to_check_field,path => "actions",exception => {case_clause,{[<<"webhook">>
,<<"webhook">>,<<"webhook">>,<<"webhook">>,<<"webhook">>,<<"webhook">>],[<<"webhook1">>]}},field => <<"http">>}}}}, path: /actions, stacktrace: [{emqx_bridge_v2_api,do_create_or_update_br
idge,5,[{file,"emqx_bridge_v2_api.erl"},{line,1439}]},{minirest_handler,apply_callback,3,[{file,"minirest_handler.erl"},{line,158}]},{minirest_handler,handle,2,[{file,"minirest_handler.er
l"},{line,56}]},{minirest_handler,init,2,[{file,"minirest_handler.erl"},{line,27}]},{cowboy_handler,execute,2,[{file,"cowboy_handler.erl"},{line,41}]},{cowboy_stream_h,execute,3,[{file,"c
owboy_stream_h.erl"},{line,318}]},{cowboy_stream_h,request_process,3,[{file,"cowboy_stream_h.erl"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}],