### PR TITLE
feat: add computed fields

### DIFF
--- a/include/hocon.hrl
+++ b/include/hocon.hrl
@@ -19,6 +19,8 @@
 -ifndef(HOCON_HRL).
 -define(HOCON_HRL, true).
 
+-define(COMPUTED, '_computed').
+
 -define(IS_VALUE_LIST(T), (T =:= array orelse T =:= concat orelse T =:= object)).
 -define(IS_FIELD(F), (is_tuple(F) andalso size(F) =:= 2)).
 


### PR DESCRIPTION
This allows us to compute fields _from checked configurations_, so we may cache arbitrary values we want to associate with the field.  Only `map()`'s and structs may have computed fields attached.  The resulting value is added to a `?COMPUTED` atom key inside the resulting checked configuration.