### PR TITLE
Add rebar3_hank plugin for detecing oxbow and dead code

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -20,6 +20,9 @@ jobs:
         run: |
           make dialyzer
           rm -f rebar.lock
+      - name: Detect dead code
+        run: |
+          make hank
       - name: Run tests
         run: |
           make eunit

--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,6 @@ erlfmt: $(REBAR)
 .PHONY: erlfmt-check
 erlfmt-check: $(REBAR)
 	$(REBAR) fmt -c
+
+hank:
+	$(REBAR) hank

--- a/rebar.config
+++ b/rebar.config
@@ -57,4 +57,15 @@
 {escript_comment, "%% Hocon 0.1.0"}.
 {escript_emu_args, "%%! +sbtu +A1\n"}.
 {yrl_opts, [verbose, warnings_as_errors]}.
-{project_plugins, [erlfmt]}.
+
+{hank, [
+    {ignore, [
+        "include/hoconsc.hrl",
+        "include/hocon_types.hrl",
+        "include/hocon.hrl",
+        %% dynamically generated file
+        "src/hocon_parser.erl"
+    ]}
+]}.
+
+{project_plugins, [erlfmt, {rebar3_hank, "1.4.1"}]}.

--- a/src/hocon_schema_json.erl
+++ b/src/hocon_schema_json.erl
@@ -55,10 +55,10 @@ gen(Schema, Opts) ->
     {RootNs, RootFields, Structs} = hocon_schema:find_structs(Schema, Opts),
     Json =
         [
-            gen_struct(RootNs, RootNs, "Root Config Keys", #{fields => RootFields}, Opts)
+            gen_struct(RootNs, "Root Config Keys", #{fields => RootFields}, Opts)
             | lists:map(
                 fun({Ns, Name, Meta}) ->
-                    case gen_struct(RootNs, Ns, Name, Meta, Opts) of
+                    case gen_struct(Ns, Name, Meta, Opts) of
                         #{fields := []} = Meta1 ->
                             error(
                                 {struct_with_no_fields, #{
@@ -79,7 +79,7 @@ gen(Schema, Opts) ->
         ],
     Json.
 
-gen_struct(_RootNs, Ns, Name, #{fields := Fields} = Meta, Opts) ->
+gen_struct(Ns, Name, #{fields := Fields} = Meta, Opts) ->
     Paths =
         case Meta of
             #{paths := Ps} -> lists:sort(maps:keys(Ps));

--- a/src/hocon_schema_md.erl
+++ b/src/hocon_schema_md.erl
@@ -64,7 +64,7 @@ fmt_struct(
         fmt_paths(Paths),
         fmt_envs(Paths, Opts),
         "\n\n**Fields**\n\n",
-        lists:map(fun(F) -> fmt_field(F, Opts) end, Fields)
+        lists:map(fun(F) -> fmt_field(F) end, Fields)
     ].
 
 fmt_paths([]) ->
@@ -95,8 +95,7 @@ fmt_field(
     #{
         name := Name,
         type := Type
-    } = Field,
-    _Opts
+    } = Field
 ) ->
     Default = fmt_default(maps:get(default, Field, undefined)),
     Desc = maps:get(desc, Field, ""),

--- a/test/hocon_schema_aliases_tests.erl
+++ b/test/hocon_schema_aliases_tests.erl
@@ -16,6 +16,8 @@
 
 -module(hocon_schema_aliases_tests).
 
+-hank([{unnecessary_function_arguments, [{incr, 2}]}]).
+
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").


### PR DESCRIPTION
This is a proposal for adding [rebar3_hank](https://github.com/AdRoll/rebar3_hank) to detect and warn about oxbow and dead code in this project.

This was the `rebar3 hank` output before the fixes (with the ignored files):
```
rebar3 hank
===> Looking for code to kill with fire...
===> The following pieces of code are dead and should be removed:
test/hocon_schema_aliases_tests.erl:218: incr/2 doesn't need its #2 argument
src/hocon_schema_md.erl:94: fmt_field/2 doesn't need its #2 argument
src/hocon_schema_json.erl:82: gen_struct/5 doesn't need its #1 argument
```