### PR TITLE
fix: pin typerefl 0.9.8

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 
 {deps, [
     {getopt, "1.0.3"},
-    {typerefl, {git, "https://github.com/ieQu1/typerefl.git", {tag, "0.9.7"}}}
+    {typerefl, {git, "https://github.com/ieQu1/typerefl.git", {tag, "0.9.8"}}}
 ]}.
 
 {edoc_opts, [{preprocess, true}]}.


### PR DESCRIPTION
typerefl 0.9.8 pins erlang_qq tag 1.0.0 instead of a branch this fixes build failures in certain environments