### PR TITLE
fix(cli): stage generated config files before commit

### DIFF
--- a/src/hocon_cli.erl
+++ b/src/hocon_cli.erl
@@ -18,11 +18,15 @@
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
--export([is_valid_now_time/1]).
+-export([atomic_write_files/2, is_valid_now_time/1, restore_backup/2]).
 -endif.
 
 -export([main/1]).
 
+-include_lib("kernel/include/file.hrl").
+
+-define(NOW_TIME_LENGTH, 19).
+-define(STALE_TMP_AGE_SECONDS, 3600).
 -define(STDERR(Str, Args), io:format(standard_error, Str ++ "~n", Args)).
 -define(STDOUT(Str, Args), io:format(Str ++ "~n", Args)).
 -define(FORMAT_TEMPLATE, [time, " [", level, "] ", msg, "\n"]).
@@ -306,6 +310,9 @@ generate(ParsedArgs) ->
     DestinationVMArgs = filename:join(AbsPath, DestinationVMArgsFilename),
     log(debug, "Generating config in: ~0p", [Destination]),
 
+    cleanup_stale_tmp_files(Destination),
+    cleanup_stale_tmp_files(DestinationVMArgs),
+
     Schema = load_schema(ParsedArgs),
     Conf = load_conf(ParsedArgs, fun log/3),
     LogFun =
@@ -319,22 +326,21 @@ generate(ParsedArgs) ->
             AppConfig = proplists:delete(vm_args, NewConfig),
             VmArgs = stringify(proplists:get_value(vm_args, NewConfig)),
 
-            %% Prune excess files
-            MaxHistory = proplists:get_value(max_history, ParsedArgs, 3) - 1,
+            Files = [
+                {DestinationVMArgs, string:join(VmArgs, "\n")},
+                {Destination, io_lib:fwrite("~p.\n", [AppConfig])}
+            ],
+            MaxHistory = proplists:get_value(max_history, ParsedArgs, 3),
+            %% Reclaim excess history before staging so an ENOSPC retry can recover.
             prune(Destination, MaxHistory),
             prune(DestinationVMArgs, MaxHistory),
-
-            case
-                {
-                    file:write_file(Destination, io_lib:fwrite("~p.\n", [AppConfig])),
-                    file:write_file(DestinationVMArgs, string:join(VmArgs, "\n"))
-                }
-            of
-                {ok, ok} ->
-                    ok;
-                {Err1, Err2} ->
-                    maybe_log_file_error(Destination, Err1),
-                    maybe_log_file_error(DestinationVMArgs, Err2),
+            case atomic_write_files(Files) of
+                ok ->
+                    %% Enforce the retention limit after both files are in place.
+                    prune(Destination, MaxHistory),
+                    prune(DestinationVMArgs, MaxHistory);
+                {error, Filename, Reason} ->
+                    log(error, "Error writing ~s: ~s", [Filename, file:format_error(Reason)]),
                     stop_deactivate()
             end
     catch
@@ -368,12 +374,101 @@ prune(Filename, MaxHistory) ->
     %% recent MaxHistory
     Path = filename:dirname(Filename),
     Ext = filename:extension(Filename),
-    Base = hd(string:tokens(filename:basename(Filename, Ext), ".")),
+    Base = generated_file_base(Filename),
+    CurrentFilename = filename:basename(Filename),
     Files =
-        lists:sort(filelib:wildcard(Base ++ ".*" ++ Ext, Path)),
+        lists:sort([
+            File
+         || File <- directory_files(Path),
+            is_generated_filename(File, Base, Ext)
+        ]),
+    HistoryFiles =
+        [filename:join([Path, F]) || F <- Files, F =/= CurrentFilename],
+    HistoryLimit = max(MaxHistory - 1, 0),
 
-    delete([filename:join([Path, F]) || F <- Files], MaxHistory),
+    delete(HistoryFiles, HistoryLimit),
     ok.
+
+cleanup_stale_tmp_files(Filename) ->
+    Path = filename:dirname(Filename),
+    Ext = filename:extension(Filename),
+    Base = generated_file_base(Filename),
+    TmpFiles =
+        [
+            File
+         || File <- directory_files(Path),
+            is_generated_tmp_filename(File, Base, Ext)
+        ],
+    Now = erlang:system_time(second),
+    lists:foreach(
+        fun(TmpFile) ->
+            maybe_cleanup_stale_tmp_file(filename:join(Path, TmpFile), Now)
+        end,
+        TmpFiles
+    ).
+
+generated_file_base(Filename) ->
+    Ext = filename:extension(Filename),
+    Root = filename:basename(Filename, Ext),
+    lists:sublist(Root, length(Root) - ?NOW_TIME_LENGTH - 1).
+
+directory_files(Path) ->
+    case file:list_dir(Path) of
+        {ok, Files} -> Files;
+        {error, _Reason} -> []
+    end.
+
+is_generated_filename(Filename, Base, Ext) ->
+    Root = filename:basename(Filename, Ext),
+    Prefix = Base ++ ".",
+    filename:extension(Filename) =:= Ext andalso
+        lists:prefix(Prefix, Root) andalso
+        is_valid_now_time(lists:nthtail(length(Prefix), Root)).
+
+is_generated_tmp_filename(Filename, Base, Ext) ->
+    case filename:extension(Filename) of
+        ".tmp" ->
+            ReversedParts =
+                lists:reverse(string:split(filename:basename(Filename, ".tmp"), ".", all)),
+            case ReversedParts of
+                [Unique, Pid | ReversedTargetParts] ->
+                    is_decimal_string(Pid) andalso
+                        is_decimal_string(Unique) andalso
+                        is_generated_filename(
+                            string:join(lists:reverse(ReversedTargetParts), "."), Base, Ext
+                        );
+                _Other ->
+                    false
+            end;
+        _Other ->
+            false
+    end.
+
+is_decimal_string([]) ->
+    false;
+is_decimal_string(String) ->
+    lists:all(fun(Char) -> Char >= $0 andalso Char =< $9 end, String).
+
+maybe_cleanup_stale_tmp_file(TmpFilename, Now) ->
+    case file:read_file_info(TmpFilename, [{time, posix}]) of
+        {ok, #file_info{type = regular, mtime = MTime}} when
+            Now - MTime >= ?STALE_TMP_AGE_SECONDS
+        ->
+            maybe_log_tmp_cleanup_error(TmpFilename, file:delete(TmpFilename));
+        {ok, _FileInfo} ->
+            ok;
+        {error, enoent} ->
+            ok;
+        {error, Reason} ->
+            log(error, "Could not inspect temporary file ~s, ~0p", [TmpFilename, Reason])
+    end.
+
+maybe_log_tmp_cleanup_error(_TmpFilename, ok) ->
+    ok;
+maybe_log_tmp_cleanup_error(_TmpFilename, {error, enoent}) ->
+    ok;
+maybe_log_tmp_cleanup_error(TmpFilename, {error, Reason}) ->
+    log(error, "Could not delete stale temporary file ~s, ~0p", [TmpFilename, Reason]).
 
 -spec delete(file:name_all(), non_neg_integer()) -> ok.
 delete(Files, MaxHistory) when length(Files) =< MaxHistory ->
@@ -390,12 +485,168 @@ do_delete([File | Files], Left) ->
     end,
     do_delete(Files, Left - 1).
 
--spec maybe_log_file_error(file:filename(), ok | {error, file_error()}) -> ok.
-maybe_log_file_error(_, ok) ->
+-spec atomic_write_files([{file:filename(), iodata()}]) ->
+    ok | {error, file:filename(), file_error()}.
+atomic_write_files(Files) ->
+    atomic_write_files(Files, fun file:rename/2).
+
+-spec atomic_write_files(
+    [{file:filename(), iodata()}],
+    fun((file:filename(), file:filename()) -> ok | {error, file_error()})
+) -> ok | {error, file:filename(), file_error()}.
+atomic_write_files(Files, RenameFun) ->
+    case stage_files(Files, []) of
+        {ok, StagedFiles} ->
+            case prepare_staged_files(StagedFiles, []) of
+                {ok, PreparedFiles} ->
+                    commit_staged_files(PreparedFiles, RenameFun, []);
+                {error, Filename, Reason, PreparedFiles} ->
+                    cleanup_staged_files(StagedFiles),
+                    cleanup_backup_files(PreparedFiles),
+                    {error, Filename, Reason}
+            end;
+        {error, Filename, Reason, StagedFiles} ->
+            cleanup_staged_files(StagedFiles),
+            {error, Filename, Reason}
+    end.
+
+stage_files([], StagedFiles) ->
+    {ok, lists:reverse(StagedFiles)};
+stage_files([{Filename, Content} | Files], StagedFiles) ->
+    case stage_file(Filename, Content) of
+        {ok, TmpFilename} ->
+            stage_files(Files, [{Filename, TmpFilename} | StagedFiles]);
+        {error, Reason} ->
+            {error, Filename, Reason, StagedFiles}
+    end.
+
+stage_file(Filename, Content) ->
+    TmpFilename = temporary_filename(Filename),
+    case file:open(TmpFilename, [write, binary, raw, exclusive]) of
+        {ok, IoDevice} ->
+            case preserve_target_mode(Filename, TmpFilename) of
+                ok ->
+                    WriteResult = write_and_sync(IoDevice, Content),
+                    CloseResult = file:close(IoDevice),
+                    case {WriteResult, CloseResult} of
+                        {ok, ok} ->
+                            {ok, TmpFilename};
+                        {{error, Reason}, _} ->
+                            _ = file:delete(TmpFilename),
+                            {error, Reason};
+                        {ok, {error, Reason}} ->
+                            _ = file:delete(TmpFilename),
+                            {error, Reason}
+                    end;
+                {error, Reason} ->
+                    _ = file:close(IoDevice),
+                    _ = file:delete(TmpFilename),
+                    {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+preserve_target_mode(Filename, TmpFilename) ->
+    case file:read_file_info(Filename) of
+        {ok, #file_info{type = regular, mode = Mode}} when is_integer(Mode) ->
+            file:change_mode(TmpFilename, Mode band 8#777);
+        _ ->
+            ok
+    end.
+
+write_and_sync(IoDevice, Content) ->
+    case file:write(IoDevice, Content) of
+        ok -> file:sync(IoDevice);
+        {error, Reason} -> {error, Reason}
+    end.
+
+prepare_staged_files([], PreparedFiles) ->
+    {ok, lists:reverse(PreparedFiles)};
+prepare_staged_files([{Filename, TmpFilename} | StagedFiles], PreparedFiles) ->
+    case backup_file(Filename) of
+        {ok, BackupFilename} ->
+            PreparedFile = {Filename, TmpFilename, BackupFilename},
+            prepare_staged_files(StagedFiles, [PreparedFile | PreparedFiles]);
+        {error, Reason} ->
+            {error, Filename, Reason, PreparedFiles}
+    end.
+
+backup_file(Filename) ->
+    case file:read_file(Filename) of
+        {ok, Content} -> stage_file(Filename, Content);
+        {error, enoent} -> {ok, none};
+        {error, Reason} -> {error, Reason}
+    end.
+
+commit_staged_files([], _RenameFun, CommittedFiles) ->
+    cleanup_backup_files(CommittedFiles),
     ok;
-maybe_log_file_error(Filename, {error, Reason}) ->
-    log(error, "Error writing ~s: ~s", [Filename, file:format_error(Reason)]),
-    ok.
+commit_staged_files(
+    [{Filename, TmpFilename, _BackupFilename} = PreparedFile | PreparedFiles],
+    RenameFun,
+    CommittedFiles
+) ->
+    case RenameFun(TmpFilename, Filename) of
+        ok ->
+            commit_staged_files(PreparedFiles, RenameFun, [PreparedFile | CommittedFiles]);
+        {error, Reason} ->
+            cleanup_staged_files([{Filename, TmpFilename} | staged_files(PreparedFiles)]),
+            cleanup_backup_files([PreparedFile | PreparedFiles]),
+            rollback_committed_files(CommittedFiles),
+            {error, Filename, Reason}
+    end.
+
+staged_files(PreparedFiles) ->
+    [{Filename, TmpFilename} || {Filename, TmpFilename, _BackupFilename} <- PreparedFiles].
+
+rollback_committed_files(CommittedFiles) ->
+    lists:foreach(fun rollback_committed_file/1, CommittedFiles).
+
+rollback_committed_file({Filename, _TmpFilename, none}) ->
+    maybe_log_rollback_delete_error(Filename, file:delete(Filename));
+rollback_committed_file({Filename, _TmpFilename, BackupFilename}) ->
+    restore_backup(Filename, BackupFilename).
+
+restore_backup(Filename, BackupFilename) ->
+    maybe_log_rollback_error(Filename, file:rename(BackupFilename, Filename)).
+
+maybe_log_rollback_delete_error(_Filename, ok) ->
+    ok;
+maybe_log_rollback_delete_error(_Filename, {error, enoent}) ->
+    ok;
+maybe_log_rollback_delete_error(Filename, {error, Reason}) ->
+    maybe_log_rollback_error(Filename, {error, Reason}).
+
+maybe_log_rollback_error(_Filename, ok) ->
+    ok;
+maybe_log_rollback_error(Filename, {error, Reason}) ->
+    log(error, "Error rolling back ~s: ~s", [Filename, file:format_error(Reason)]).
+
+cleanup_staged_files(StagedFiles) ->
+    lists:foreach(
+        fun({_Filename, TmpFilename}) ->
+            _ = file:delete(TmpFilename)
+        end,
+        StagedFiles
+    ).
+
+cleanup_backup_files(PreparedFiles) ->
+    lists:foreach(
+        fun
+            ({_Filename, _TmpFilename, none}) -> ok;
+            ({_Filename, _TmpFilename, BackupFilename}) -> _ = file:delete(BackupFilename)
+        end,
+        PreparedFiles
+    ).
+
+temporary_filename(Filename) ->
+    lists:flatten(
+        io_lib:format(
+            "~s.~s.~B.tmp",
+            [Filename, os:getpid(), erlang:unique_integer([positive, monotonic])]
+        )
+    ).
 
 filename_maker(Filename, NowTime, Extension) ->
     lists:flatten(io_lib:format("~s.~s.~s", [Filename, NowTime, Extension])).

--- a/test/hocon_cli_tests.erl
+++ b/test/hocon_cli_tests.erl
@@ -17,6 +17,7 @@
 -module(hocon_cli_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/file.hrl").
 
 -define(assertPrinted(___Text),
     (fun() ->
@@ -112,6 +113,23 @@ generate_multiple_input_config_test() ->
     ?assertEqual("yaa", proplists:get_value(setting, Plist)).
 
 generate_opts(T) -> ["-t", T, "-d", out(), "generate"].
+
+generate_with_schema_opts(Time, MaxHistory, Dir) ->
+    generate_with_schema_opts(Time, MaxHistory, Dir, []).
+
+generate_with_schema_opts(Time, MaxHistory, Dir, ExtraOpts) ->
+    [
+        "-c",
+        etc("demo-schema-example-1.conf"),
+        "-s",
+        "demo_schema",
+        "-t",
+        Time,
+        "-m",
+        integer_to_list(MaxHistory),
+        "-d",
+        Dir
+    ] ++ ExtraOpts ++ ["generate"].
 
 now_time_test() ->
     ?CAPTURING(begin
@@ -336,6 +354,290 @@ prune_test() ->
     NewAppConfigs = lists:sort(filelib:wildcard("app.*.config", out())),
     % check if old one has been deleted, not new one
     ?assertEqual(lists:nth(1, NewAppConfigs), lists:nth(2, AppConfigs)).
+
+generation_with_older_timestamp_keeps_current_files_test() ->
+    Dir = filename:join(out(), atom_to_list(?FUNCTION_NAME)),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+    CurrentTime = "2000.01.01.00.00.00",
+    ExistingTimes = ["2000.01.01.00.00.01", "2000.01.01.00.00.02"],
+    ExistingFiles =
+        [
+            filename:join(Dir, Prefix ++ "." ++ Time ++ "." ++ Extension)
+         || {Prefix, Extension} <- [{"app", "config"}, {"vm", "args"}],
+            Time <- ExistingTimes
+        ],
+    lists:foreach(fun(Filename) -> ok = file:write_file(Filename, <<"old">>) end, ExistingFiles),
+    CurrentAppConfig = filename:join(Dir, "app." ++ CurrentTime ++ ".config"),
+    CurrentVMArgs = filename:join(Dir, "vm." ++ CurrentTime ++ ".args"),
+    try
+        ok = hocon_cli:main(generate_with_schema_opts(CurrentTime, 2, Dir)),
+        ?assert(filelib:is_regular(CurrentAppConfig)),
+        ?assert(filelib:is_regular(CurrentVMArgs)),
+        ?assertEqual(
+            lists:sort([
+                CurrentAppConfig,
+                filename:join(Dir, "app.2000.01.01.00.00.02.config")
+            ]),
+            lists:sort(filelib:wildcard(filename:join(Dir, "app.*.config")))
+        ),
+        ?assertEqual(
+            lists:sort([
+                CurrentVMArgs,
+                filename:join(Dir, "vm.2000.01.01.00.00.02.args")
+            ]),
+            lists:sort(filelib:wildcard(filename:join(Dir, "vm.*.args")))
+        )
+    after
+        cleanup_dir(Dir)
+    end.
+
+generation_prunes_only_matching_dest_file_test() ->
+    Dir = filename:join(out(), atom_to_list(?FUNCTION_NAME)),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+    OldCustomConfig = filename:join(Dir, "app.custom.1999.01.01.00.00.00.config"),
+    OtherConfig = filename:join(Dir, "app.other.1999.01.01.00.00.00.config"),
+    ManualConfig = filename:join(Dir, "app.manual.config"),
+    OtherTmp = OtherConfig ++ ".123.1.tmp",
+    ManualTmp = filename:join(Dir, "app.custom.1999.01.01.00.00.00.config.backup.manual.tmp"),
+    UnrelatedFiles = [OldCustomConfig, OtherConfig, ManualConfig] ++ [OtherTmp, ManualTmp],
+    lists:foreach(
+        fun(Filename) -> ok = file:write_file(Filename, <<"unrelated">>) end,
+        UnrelatedFiles
+    ),
+    StaleMTime = erlang:system_time(second) - 3601,
+    ok = set_mtimes([OtherTmp, ManualTmp], StaleMTime),
+    try
+        ok = hocon_cli:main(
+            generate_with_schema_opts(
+                "2000.01.01.00.00.01",
+                1,
+                Dir,
+                ["-f", "app.custom"]
+            )
+        ),
+        ?assertNot(filelib:is_file(OldCustomConfig)),
+        ?assert(filelib:is_regular(OtherConfig)),
+        ?assert(filelib:is_regular(ManualConfig)),
+        ?assert(filelib:is_regular(OtherTmp)),
+        ?assert(filelib:is_regular(ManualTmp)),
+        ?assert(
+            filelib:is_regular(
+                filename:join(Dir, "app.custom.2000.01.01.00.00.01.config")
+            )
+        )
+    after
+        cleanup_dir(Dir)
+    end.
+
+stale_tmp_files_are_cleaned_before_generation_test() ->
+    Dir = filename:join(out(), atom_to_list(?FUNCTION_NAME)),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+    StaleAppTmp = filename:join(Dir, "app.2000.01.01.00.00.00.config.123.1.tmp"),
+    StaleVMArgsTmp = filename:join(Dir, "vm.2000.01.01.00.00.00.args.123.2.tmp"),
+    FreshAppTmp = filename:join(Dir, "app.2000.01.01.00.00.00.config.456.3.tmp"),
+    lists:foreach(
+        fun(Filename) -> ok = file:write_file(Filename, <<"tmp">>) end,
+        [StaleAppTmp, StaleVMArgsTmp, FreshAppTmp]
+    ),
+    StaleMTime = erlang:system_time(second) - 3601,
+    ok = set_mtimes([StaleAppTmp, StaleVMArgsTmp], StaleMTime),
+    try
+        ok = hocon_cli:main([
+            "-c",
+            etc("demo-schema-example-1.conf"),
+            "-s",
+            "demo_schema",
+            "-t",
+            "2000.01.01.00.00.01",
+            "-d",
+            Dir,
+            "generate"
+        ]),
+        ?assertNot(filelib:is_file(StaleAppTmp)),
+        ?assertNot(filelib:is_file(StaleVMArgsTmp)),
+        ?assert(filelib:is_regular(FreshAppTmp))
+    after
+        cleanup_dir(Dir)
+    end.
+
+cleanup_dir(Dir) ->
+    case file:list_dir(Dir) of
+        {ok, Files} ->
+            lists:foreach(fun(Filename) -> file:delete(filename:join(Dir, Filename)) end, Files);
+        {error, enoent} ->
+            ok
+    end,
+    file:del_dir(Dir),
+    ok.
+
+set_mtime(Filename, MTime) ->
+    file:write_file_info(Filename, #file_info{mtime = MTime}, [{time, posix}]).
+
+set_mtimes(Filenames, MTime) ->
+    lists:foreach(fun(Filename) -> ok = set_mtime(Filename, MTime) end, Filenames).
+
+restore_backup_failure_preserves_target_test() ->
+    Dir = filename:join(out(), atom_to_list(?FUNCTION_NAME)),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+    Target = filename:join(Dir, "app.config"),
+    MissingBackup = filename:join(Dir, "missing.tmp"),
+    ok = file:write_file(Target, <<"current">>),
+    try
+        ok = hocon_cli:restore_backup(Target, MissingBackup),
+        ?assertEqual({ok, <<"current">>}, file:read_file(Target))
+    after
+        cleanup_dir(Dir)
+    end.
+
+atomic_write_preserves_existing_modes_test() ->
+    Dir = filename:join(out(), atom_to_list(?FUNCTION_NAME)),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+    AppConfig = filename:join(Dir, "app.config"),
+    VMArgs = filename:join(Dir, "vm.args"),
+    lists:foreach(
+        fun(Filename) ->
+            ok = file:write_file(Filename, <<"old">>),
+            ok = file:change_mode(Filename, 8#600)
+        end,
+        [AppConfig, VMArgs]
+    ),
+    try
+        ?assertEqual(
+            ok,
+            hocon_cli:atomic_write_files(
+                new_config_files(VMArgs, AppConfig),
+                fun file:rename/2
+            )
+        ),
+        ?assertEqual({ok, <<"new app config">>}, file:read_file(AppConfig)),
+        ?assertEqual({ok, <<"new vm args">>}, file:read_file(VMArgs)),
+        ?assertEqual(8#600, file_mode(AppConfig)),
+        ?assertEqual(8#600, file_mode(VMArgs))
+    after
+        cleanup_dir(Dir)
+    end.
+
+atomic_prepare_failure_preserves_targets_test() ->
+    Dir = filename:join(out(), atom_to_list(?FUNCTION_NAME)),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+    VMArgs = filename:join(Dir, "vm.args"),
+    AppConfig = filename:join(Dir, "app.config"),
+    ok = file:write_file(VMArgs, <<"old vm args">>),
+    ok = file:make_dir(AppConfig),
+    try
+        ?assertEqual(
+            {error, AppConfig, eisdir},
+            hocon_cli:atomic_write_files(
+                new_config_files(VMArgs, AppConfig),
+                fun file:rename/2
+            )
+        ),
+        ?assertEqual({ok, <<"old vm args">>}, file:read_file(VMArgs)),
+        ?assert(filelib:is_dir(AppConfig)),
+        ?assertEqual([], filelib:wildcard(filename:join(Dir, "*.tmp")))
+    after
+        _ = file:delete(VMArgs),
+        _ = file:del_dir(AppConfig),
+        _ = file:del_dir(Dir)
+    end.
+
+file_mode(Filename) ->
+    {ok, #file_info{mode = Mode}} = file:read_file_info(Filename),
+    Mode band 8#777.
+
+generation_failure_preserves_retained_history_test() ->
+    Dir = filename:join(out(), atom_to_list(?FUNCTION_NAME)),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+    OldestTime = "2000.01.01.00.00.00",
+    RetainedTime = "2000.01.01.00.00.01",
+    NewTime = "2000.01.01.00.00.02",
+    OldestAppConfig = filename:join(Dir, "app." ++ OldestTime ++ ".config"),
+    OldestVMArgs = filename:join(Dir, "vm." ++ OldestTime ++ ".args"),
+    RetainedAppConfig = filename:join(Dir, "app." ++ RetainedTime ++ ".config"),
+    RetainedVMArgs = filename:join(Dir, "vm." ++ RetainedTime ++ ".args"),
+    NewAppConfig = filename:join(Dir, "app." ++ NewTime ++ ".config"),
+    NewVMArgs = filename:join(Dir, "vm." ++ NewTime ++ ".args"),
+    lists:foreach(
+        fun(Filename) -> ok = file:write_file(Filename, <<"old">>) end,
+        [OldestAppConfig, OldestVMArgs, RetainedAppConfig, RetainedVMArgs]
+    ),
+    ok = file:make_dir(NewVMArgs),
+    try
+        ?assertThrow(
+            stop_deactivate,
+            hocon_cli:main(generate_with_schema_opts(NewTime, 2, Dir))
+        ),
+        ?assertNot(filelib:is_file(OldestAppConfig)),
+        ?assertNot(filelib:is_file(OldestVMArgs)),
+        ?assert(filelib:is_regular(RetainedAppConfig)),
+        ?assert(filelib:is_regular(RetainedVMArgs)),
+        ?assertNot(filelib:is_file(NewAppConfig)),
+        ?assert(filelib:is_dir(NewVMArgs)),
+        ?assertEqual([], filelib:wildcard(filename:join(Dir, "*.tmp")))
+    after
+        _ = file:delete(OldestAppConfig),
+        _ = file:delete(OldestVMArgs),
+        _ = file:delete(RetainedAppConfig),
+        _ = file:delete(RetainedVMArgs),
+        _ = file:delete(NewAppConfig),
+        _ = file:del_dir(NewVMArgs),
+        _ = file:del_dir(Dir)
+    end.
+
+atomic_commit_failure_removes_partial_generation_test() ->
+    atomic_commit_failure_test(?FUNCTION_NAME, {error, enoent}, {error, enoent}).
+
+atomic_commit_failure_restores_existing_targets_test() ->
+    atomic_commit_failure_test(
+        ?FUNCTION_NAME,
+        {ok, <<"old app config">>},
+        {ok, <<"old vm args">>}
+    ).
+
+atomic_commit_failure_test(TestName, ExpectedAppConfig, ExpectedVMArgs) ->
+    Dir = filename:join(out(), atom_to_list(TestName)),
+    ok = filelib:ensure_dir(filename:join(Dir, "dummy")),
+    AppConfig = filename:join(Dir, "app.config"),
+    VMArgs = filename:join(Dir, "vm.args"),
+    ok = maybe_write_file(AppConfig, ExpectedAppConfig),
+    ok = maybe_write_file(VMArgs, ExpectedVMArgs),
+    RenameCountKey = {?MODULE, TestName},
+    try
+        ?assertEqual(
+            {error, AppConfig, eacces},
+            hocon_cli:atomic_write_files(
+                new_config_files(VMArgs, AppConfig),
+                fail_second_rename(RenameCountKey)
+            )
+        ),
+        ?assertEqual(ExpectedAppConfig, file:read_file(AppConfig)),
+        ?assertEqual(ExpectedVMArgs, file:read_file(VMArgs)),
+        ?assertEqual([], filelib:wildcard(filename:join(Dir, "*.tmp")))
+    after
+        erlang:erase(RenameCountKey),
+        _ = file:delete(AppConfig),
+        _ = file:delete(VMArgs),
+        _ = file:del_dir(Dir)
+    end.
+
+new_config_files(VMArgs, AppConfig) ->
+    [{VMArgs, <<"new vm args">>}, {AppConfig, <<"new app config">>}].
+
+maybe_write_file(Filename, {ok, Content}) ->
+    file:write_file(Filename, Content);
+maybe_write_file(_Filename, {error, enoent}) ->
+    ok.
+
+fail_second_rename(RenameCountKey) ->
+    fun(From, To) ->
+        case erlang:get(RenameCountKey) of
+            undefined ->
+                erlang:put(RenameCountKey, 1),
+                file:rename(From, To);
+            1 ->
+                {error, eacces}
+        end
+    end.
 
 %% etc-path
 etc(Name) ->


### PR DESCRIPTION
## Problem

When disk space is exhausted (`ENOSPC`), writing generated `app.<time>.config` and `vm.<time>.args` directly can create or truncate final files before the write fails. A later startup may then pick up a 0-byte or incomplete generated configuration.

Failure-path review also found that earlier revisions could delete an existing target, publish only one of the two generated files, accumulate abandoned temp files, prune the just-written generation, or fail to reclaim excess history before an ENOSPC retry.

## Solution

- Stage both generated outputs in unique, exclusive temporary files in the destination directory.
- Apply an existing regular target's permission bits to its staging/rollback file before writing content.
- Write, `sync`, and close every temporary file before committing either output.
- Keep a synced rollback copy only when replacing a pre-existing target.
- Rename `vm.args` first and `app.config` last.
- If a later rename returns an error, roll back earlier commits in reverse order:
  - remove a target created by this generation; or
  - restore the previous target contents from its rollback copy.
- Clean up uncommitted temporary files and rollback copies on handled failure paths.
- Remove stale temp files only when they match the exact generated target family and numeric temp suffix format.
- Prune excess history before staging to reclaim space, excluding the current destination and reserving one slot for it; prune again after commit to enforce the final limit.
- Match history by the complete destination base, extension, and timestamp shape so a dotted `--dest_file` cannot prune another config family.

This provides rollback for handled staging/rename errors. It does not claim a strict two-file ACID transaction across process crashes, concurrent generators, or power loss.

## Regression tests

Coverage includes:

- staging and backup-preparation failures preserving existing targets;
- an injected second-rename failure removing a partial new generation;
- the same failure restoring pre-existing target contents;
- an older explicit timestamp retaining the current generation during pruning;
- exact file-family pruning for dotted destination names;
- stale temp cleanup without deleting fresh, unrelated-family, or non-generated temp files;
- replacement preserving existing regular-file permission bits;
- a failed backup restore preserving the current target and logging the rename error.

## Testing

- Erlang/OTP 23: production `rebar3 compile` passed
- Erlang/OTP 26: Elvis passed; both changed files pass erlfmt
- Erlang/OTP 27: Dialyzer, xref, full EUnit, and coverage passed — 584 tests
- Erlang/OTP 28: Dialyzer, full EUnit, and coverage passed — 584 tests
- Erlang/OTP 28: `hocon_cli_tests` passed — 25 tests
- Real 1 MiB tmpfs ENOSPC injection:
  - second staging write failed with both old targets intact and no temp files;
  - rollback-backup preparation failed with both old targets intact and no temp files;
  - pre-prune reclaimed enough space for generation to succeed with the final retention limit enforced.
- `git diff --check` passed
