### PR TITLE
fix: report incomplete UTF-8 early

### DIFF
--- a/src/hocon_token.erl
+++ b/src/hocon_token.erl
@@ -59,7 +59,7 @@ read(Filename) ->
 -spec scan(binary() | string(), hocon:ctx()) -> list().
 scan(Input, Ctx) when is_binary(Input) ->
     case unicode_list(Input) of
-        {error, _Ok, Invalid} ->
+        {Status, _Ok, Invalid} when Status =:= error; Status =:= incomplete ->
             throw({scan_invalid_utf8, Invalid, Ctx});
         InputList ->
             scan(InputList, Ctx)

--- a/test/data/incomplete-utf8.conf
+++ b/test/data/incomplete-utf8.conf
@@ -1,0 +1,2 @@
+key = value
+â‚

--- a/test/hocon_tests.erl
+++ b/test/hocon_tests.erl
@@ -1079,6 +1079,13 @@ invalid_utf8_test() ->
         hocon:load("./test/data/invalid-utf8.conf")
     ).
 
+incomplete_utf8_test() ->
+    Incomplete = <<16#E2, 16#82>>,
+    ?assertMatch(
+        {error, {scan_invalid_utf8, Incomplete, _}},
+        hocon:load("./test/data/incomplete-utf8.conf")
+    ).
+
 empty_map_test_() ->
     [
         ?_assertEqual({ok, #{<<"a">> => #{}}}, hocon:binary("a={}")),


### PR DESCRIPTION
## Summary

This PR reports incomplete UTF-8 HOCON string early as a regular scan error instead of crashing later during parsing.