### PR TITLE
fix(scanner): accept the b and B byte units unquoted

### DIFF
--- a/etc/convert-sample.conf
+++ b/etc/convert-sample.conf
@@ -3,8 +3,8 @@ min = 1m
 hour = 1h
 day = 1d
 
-b = "256b"
-B = "256B"
+b = 256b
+B = 256B
 kb = 1kb
 KB = 1KB
 mb = 1mb

--- a/src/hocon_scanner.xrl
+++ b/src/hocon_scanner.xrl
@@ -62,7 +62,7 @@ MultilineString     = """{MultilineChar}*"""
 
 %% Bytesize and Duration
 Percent             = {Digit}+%
-Bytesize            = {Digit}+(kb|KB|mb|MB|gb|GB)
+Bytesize            = {Digit}+(b|B|kb|KB|mb|MB|gb|GB)
 Duration            = {Digit}+(d|D|h|H|m|M|s|S|ms|MS)
 %%Duration            = {Digit}+(d|h|m|s|ms|us|ns)
 


### PR DESCRIPTION
Fixes the unit asymmetry reported in [emqx/emqx#18422](https://github.com/emqx/emqx/issues/18422): `max_packet_size = 1MB` parses, but `max_packet_size = 1B` requires quotes.

## Cause

`src/hocon_scanner.xrl` listed only the two-letter units:

```
Bytesize            = {Digit}+(kb|KB|mb|MB|gb|GB)
```

So `1MB` scans as one `string` token, while `1B` scans as `integer(1)` followed by unquoted `B`. Those two cannot concatenate, so it is a parse error. `"1B"` works because quoting produces a single string token.

`hocon_postprocess:do_bytesize/1` already accepted `b` and `B` — its regex is `^\s*([0-9]+)(b|B|kb|KB|mb|MB|gb|GB)$` — so only the scanner was missing them.

## Before / after

```
             before              after
1MB     ->   <<"1MB">>           <<"1MB">>
1KB     ->   <<"1KB">>           <<"1KB">>
1GB     ->   <<"1GB">>           <<"1GB">>
1B      ->   parse_error         <<"1B">>
1b      ->   parse_error         <<"1b">>
"1B"    ->   <<"1B">>            <<"1B">>
1s      ->   <<"1s">>            <<"1s">>
100%    ->   <<"100%">>          <<"100%">>
```

With `convert => [bytesize]`, values convert as expected and malformed ones are left alone rather than turned into a number:

```
1B -> 1        1b -> 1        1MB -> 1048576
1bar -> <<"1bar">>            1kbkb -> <<"1kbkb">>
```

## Behaviour change worth noting

Inputs of the form `<digits>b<more>` previously failed to parse and now scan as `string ++ unquoted`, which HOCON concatenates:

```
1build  ->  before: parse_error   after: <<"1build">>
1bar    ->  before: parse_error   after: <<"1bar">>
```

This only widens what parses; no previously valid value changes meaning. It also matches how `<digits>kb<more>` already behaved — `1kbkb` parsed as `<<"1kbkb">>` before this change and still does. Such values remain strings after `bytesize` conversion, so a schema typed as `bytesize` still rejects them.

## Test

`etc/convert-sample.conf` already encoded the asymmetry — its `b` and `B` entries were quoted while every other unit was bare:

```
b = "256b"
B = "256B"
kb = 1kb
```

Unquoting them makes the existing expectations in `hocon_tests` (`b => 256`, `B => 256`) cover the case that used to fail. `make eunit` passes 585 tests; `make xref` is clean.